### PR TITLE
Fixing Travis: updated root binary to support Minuit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
 
 env:
   matrix:
-    - ROOT=5-32-04
-    - ROOT=5-34-08
+    - ROOT=5.34.14
 
 install:
   # Check if we are running Python 2 or 3. This is needed for the apt-get package names
@@ -30,7 +29,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then time sudo apt-get install -qq python${PYTHON_SUFFIX}-matplotlib python${PYTHON_SUFFIX}-tables; fi
 
   # Install a ROOT binary that we custom-built in a 64-bit Ubuntu VM
-  # for the correct Python / ROOT version
+  # for the correct python / ROOT version
   - time wget --no-check-certificate https://senkin.web.cern.ch/senkin/root_builds/root_v${ROOT}_python_${TRAVIS_PYTHON_VERSION}.tar.gz
   - time tar zxf root_v${ROOT}_python_${TRAVIS_PYTHON_VERSION}.tar.gz
   - mv root_v${ROOT}_python_${TRAVIS_PYTHON_VERSION} root


### PR DESCRIPTION
The root binary ([root_v5.34.14_Python_2.7.tar.gz](https://senkin.web.cern.ch/senkin/root_builds/root_v5.34.14_Python_2.7.tar.gz)) is now custom-built using 64-bit Ubuntu VM, and is now stored in my private lxplus area until @kreczko revives vivaldi.
