### PR TITLE
Cleaning up a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ cd DailyPythonScripts
 # get submodules:
 git submodule init && git submodule update
 
+# change matplotlib branch to 1.3.1 (stable version)
+cd external/matplotlib
+git co 1.3.1
+cd -
+
 # setup run:
 ./setup_standalone.sh
 


### PR DESCRIPTION
- updated readme to have this: [![build status](https://travis-ci.org/BristolTopGroup/DailyPythonScripts.png)](https://travis-ci.org/BristolTopGroup/DailyPythonScripts)
- updated the recipe
- matplotlib version 1.3.1 is specifically used as a stable one
- the issue with freetype2 (matplotlib dependency) not being found in CMSSW fixed by manually installing freetype on soolin (thanks @kreczko)
