### PR TITLE
Change in pick_bins.py: scale to lumi

### DIFF
--- a/src/cross_section_measurement/00_pick_bins.py
+++ b/src/cross_section_measurement/00_pick_bins.py
@@ -58,11 +58,11 @@ def main():
     s_min = 0.5
     # we also want the statistical error to be larger than 5%
     # this translates (error -= 1/sqrt(N)) to (1/0.05)^2 = 400
-    n_min = 200
+    n_min = 100
 #     n_min = 200 # N = 200 -> 7.1 % stat error
      
     
-    for variable in ['MET']:  # , 'HT', 'ST', 'MT', 'WPT']:
+    for variable in ['MET', 'HT', 'ST', 'MT', 'WPT']:
         histogram_information = get_histograms( variable )
         
         best_binning, histogram_information = get_best_binning( histogram_information , p_min, s_min, n_min )
@@ -91,7 +91,7 @@ def get_histograms( variable ):
     
     path_electron = ''
     path_muon = ''
-    histogram_name = 'response_withoutFakes'
+    histogram_name = 'response_without_fakes'
     if variable == 'MET':
         path_electron = 'unfolding_MET_analyser_electron_channel_patType1CorrectedPFMet/%s' % histogram_name
         path_muon = 'unfolding_MET_analyser_muon_channel_patType1CorrectedPFMet/%s' % histogram_name
@@ -129,7 +129,13 @@ def get_histograms( variable ):
     
     for histogram in histogram_information:
         f = File( histogram['file'] )
+        # scale to lumi
+        nEvents = f.EventFilter.EventCounter.GetBinContent( 1 )  # number of processed events 
+        config = XSectionConfig( histogram['CoM'] )
+        lumiweight = config.ttbar_xsection * config.new_luminosity / nEvents
+
         histogram['hist'] = f.Get( histogram['path'] ).Clone()
+        histogram['hist'].Scale( lumiweight )
         # change scope from file to memory
         histogram['hist'].SetDirectory( 0 )
         f.close()


### PR DESCRIPTION
As discussed in the meeting, now scaling the histograms to luminosity. Results for MET with a minimum of 100 events in each bin (up to discussion):

```
The best binning for MET is:
bin edges = [0.0, 27.0, 52.0, 87.0, 129.0, 171.0, 300.0]
N_bins    = 6
------------------------------------------------------------------------------------------------------------------------
The corresponding purities and stabilities are:
CoM = 7 channel = electron
p_i = [0.65, 0.592, 0.542, 0.545, 0.532, 0.714]
p_i (old) = [0.717, 0.589, 0.546, 0.573, 0.571, 0.702]
s_i = [0.539, 0.542, 0.638, 0.663, 0.629, 0.83]
s_i (old) = [0.595, 0.567, 0.659, 0.687, 0.67, 0.831]
N   = [1592, 2567, 1994, 771, 224, 148]
************************************************************************************************************************
CoM = 7 channel = muon
p_i = [0.648, 0.591, 0.557, 0.551, 0.538, 0.713]
p_i (old) = [0.716, 0.593, 0.554, 0.566, 0.565, 0.693]
s_i = [0.541, 0.541, 0.641, 0.671, 0.633, 0.844]
s_i (old) = [0.599, 0.566, 0.659, 0.68, 0.663, 0.828]
N   = [1675, 2726, 2292, 886, 249, 164]
************************************************************************************************************************
CoM = 8 channel = electron
p_i = [0.633, 0.556, 0.505, 0.513, 0.505, 0.701]
p_i (old) = [0.707, 0.558, 0.508, 0.541, 0.548, 0.699]
s_i = [0.504, 0.508, 0.604, 0.637, 0.601, 0.838]
s_i (old) = [0.569, 0.534, 0.63, 0.654, 0.661, 0.859]
N   = [7009, 10830, 8672, 3593, 1071, 788]
************************************************************************************************************************
CoM = 8 channel = muon
p_i = [0.636, 0.562, 0.526, 0.503, 0.507, 0.702]
p_i (old) = [0.702, 0.565, 0.522, 0.521, 0.542, 0.697]
s_i = [0.511, 0.514, 0.609, 0.642, 0.603, 0.844]
s_i (old) = [0.568, 0.54, 0.625, 0.658, 0.657, 0.829]
N   = [8073, 12741, 10886, 4213, 1254, 943]
************************************************************************************************************************
========================================================================================================================

```
