### PR TITLE
Change setting of python path in environment.sh

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -11,6 +11,8 @@ cd $base
 export PYTHONPATH=$PYTHONPATH:`pwd`
 
 if [ ! -z "$CMSSW_BASE" ]; then
+	echo "CMSSW has been set up..."
+	echo "...giving priority to vpython."
     export PYTHONPATH=$vpython/lib/python2.7/site-packages:$PYTHONPATH
     export PYTHONPATH=$vpython/lib/python2.6/site-packages:$PYTHONPATH
 fi


### PR DESCRIPTION
PYTHONPATH is set to pick up vpython environment when CMSSW is setup, not just when you are on soolin.
