### PR TITLE
[MRG] More fixes/improvements

### DIFF
--- a/bin/plot
+++ b/bin/plot
@@ -90,7 +90,7 @@ labels = []
 plot_options = {}
 global_options = ['files', 'histograms', 'labels', 'plot_type', 'output_folder',
                   'output_format', 'command', 'data_index', 'normalise',
-                  'show_ratio', 'show_stat_errors_on_mc', 'colours']
+                  'show_ratio', 'show_stat_errors_on_mc', 'colours', 'name_prefix']
 
 def main():
     options, input_values_sets, json_input_files = parse_options()
@@ -160,8 +160,10 @@ def _exit_( msg ):
 def prepare_inputs( input_values ):
     input_values = check_and_fix_inputs( input_values )
     global files, histograms, global_options
-
     sets = group_by_command( input_values['command'] )
+    if input_values.has_key('name_prefix'):
+        for s in sets:
+            s.name = input_values['name_prefix'] + s.name
 
     # now we have to group the plot options
     plot_options = []

--- a/bin/plot
+++ b/bin/plot
@@ -13,6 +13,9 @@ Configuration keys
         compare-hists to compare different histograms in the same file
     files: 
         list of ROOT files for input (>= 1)
+        
+    file-aliases:
+        list of aliases for files. Used for naming in case command=='compare-hists'.
     
     histograms: 
         list of full histogram paths inside the files
@@ -77,7 +80,7 @@ Example JSON config structure:
 from optparse import OptionParser
 import sys
 from os.path import exists
-from tools.ROOT_utililities import set_root_defaults
+from tools.ROOT_utils import set_root_defaults
 from tools.file_utilities import write_data_to_JSON, read_data_from_JSON
 from tools.HistSet import HistSet
 from copy import deepcopy
@@ -85,10 +88,11 @@ from copy import deepcopy
 supported_commands = ['compare-files', 'compare-hists']
 
 files = []
+file_aliases = []
 histograms = []
 labels = []
 plot_options = {}
-global_options = ['files', 'histograms', 'labels', 'plot_type', 'output_folder',
+global_options = ['files', 'file-aliases', 'histograms', 'labels', 'plot_type', 'output_folder',
                   'output_format', 'command', 'data_index', 'normalise',
                   'show_ratio', 'show_stat_errors_on_mc', 'colours', 'name_prefix']
 
@@ -123,7 +127,7 @@ def parse_options():
     return options, input_values_sets, json_input_files
 
 def check_and_fix_inputs( input_values ):
-    global files, histograms, labels, plot_options, supported_commands
+    global files, file_aliases, histograms, labels, plot_options, supported_commands
     
     if not input_values['command'] in supported_commands:
         _exit_( 'Command "%s" is not supported. Exiting ...' % input_values['command'] )
@@ -136,6 +140,14 @@ def check_and_fix_inputs( input_values ):
             # check if they exist
             if not exists( f ):
                 return False, 'File "%s" does not exist' % f
+    if not input_values.has_key('file-aliases') or len(input_values['file-aliases']) == 0:
+        for f in files:
+            name = f.split( '/' )[-1]
+            name = name.replace( '.root', '' )
+            file_aliases.append(name)
+    else:
+        file_aliases = input_values['file-aliases']
+            
     if not input_values.has_key('histograms') or len(input_values['histograms']) == 0:
         _exit_( 'No histograms have been defined.' )
     else:
@@ -220,12 +232,10 @@ def group_by_file():
         Creates:
         [{name:{f:h}, ...] where f = file and h = histogram path. The name is taken from the file name
     '''
-    global files, histograms, labels
+    global files, file_aliases, histograms, labels
     hist_sets = []
-    for f in files:
+    for f,name in zip(files, file_aliases):
         hist_set = []
-        name = f.split( '/' )[-1]
-        name = name.replace( '.root', '' )
         for histogram in histograms:
             hist_set.append( ( f, histogram ) )
         hist_sets.append( HistSet( name, hist_inputs = hist_set, output_hist_labels = labels ) )

--- a/bin/run_x_section_measurement
+++ b/bin/run_x_section_measurement
@@ -1,14 +1,14 @@
 #!/bin/bash
 echo "Running differential cross-section analysis for 7 and 8 TeV data"
-bash x_01_all_vars
+time bash x_01_all_vars
 wait
-bash x_02_all_vars
+time bash x_02_all_vars
 wait
-bash x_03_all_vars
+time bash x_03_all_vars
 wait
-bash x_04_all_vars
+time bash x_04_all_vars
 wait
-bash x_05_all_vars
+time bash x_05_all_vars
 wait
 
 echo "Everything is done. Time to run make_analysis_note and go home!"

--- a/bin/x_04_all_vars
+++ b/bin/x_04_all_vars
@@ -11,7 +11,7 @@ echo "Using the fit variable(s): $fit_var"
 i=0
 for var in MET HT ST MT WPT; do
 	echo "Plotting diff. x-section for distribution: $var"
-	nohup time python src/cross_section_measurement/04_make_plots_matplotlib.py -v $var -c 7 -p data/$nice_fit_var -a &> logs/04_${var}_plot_7TeV_${nice_fit_var}.log &
+	nohup time python src/cross_section_measurement/04_make_plots_matplotlib.py -v $var -c 7 -p data/$nice_fit_var &> logs/04_${var}_plot_7TeV_${nice_fit_var}.log &
 	let i+=1
 	if (( $i % N_JOBS == 0 ))
 	then
@@ -19,7 +19,7 @@ for var in MET HT ST MT WPT; do
     	wait;
 	fi
 	
-	nohup time python src/cross_section_measurement/04_make_plots_matplotlib.py -v $var -c 8 -p data/$nice_fit_var -a &> logs/04_${var}_plot_8TeV_${nice_fit_var}.log &
+	nohup time python src/cross_section_measurement/04_make_plots_matplotlib.py -v $var -c 8 -p data/$nice_fit_var &> logs/04_${var}_plot_8TeV_${nice_fit_var}.log &
 	let i+=1
 	if (( $i % N_JOBS == 0 ))
 	then

--- a/config/plots/HT_reco_gen_truth_comparison_8TeV.json
+++ b/config/plots/HT_reco_gen_truth_comparison_8TeV.json
@@ -1,0 +1,39 @@
+{
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/unfolding/unfolding_TTJets_8TeV.root"
+    ], 
+    "histograms": [
+        "unfolding_HT_analyser_electron_channel/measured",
+        "unfolding_HT_analyser_electron_channel/truth"
+    ], 
+    "labels": [
+        "measured", 
+        "truth"
+    ], 
+    "output_folder": "plots/TTJet_comparison", 
+    "output_format": ["pdf"], 
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0, 3]
+    ], 
+    "title": [
+        "Comparison of TTJets MC (measured, truth) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+        "$H_T$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 1000]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(10 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.05]
+    ],
+    "rebin" : [
+    	10	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_reco_fake_comparison_8TeV.json
+++ b/config/plots/MET_reco_fake_comparison_8TeV.json
@@ -1,0 +1,43 @@
+{
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/unfolding/unfolding_TTJets_8TeV.root"
+    ], 
+    "file-aliases": [ 
+        "TTJets"
+    ], 
+    "histograms": [
+        "unfolding_MET_analyser_electron_channel_patType1CorrectedPFMet/measured",
+        "unfolding_MET_analyser_electron_channel_patType1CorrectedPFMet/fake"
+    ], 
+    "labels": [
+        "measured", 
+        "fake"
+    ], 
+    "output_folder": "plots/TTJet_comparison", 
+    "output_format": ["pdf"], 
+    "name_prefix": "comparison_measured_fake",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0, 2.5]
+    ], 
+    "title": [
+        "Comparison of TTJets MC (measured, truth) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+        "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area"
+    ], 
+    "y_limits": [
+        [0, 0.4]
+    ],
+    "rebin" : [
+    	[0.0, 27.0, 52.0, 87.0, 130.0, 172.0, 300]	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_uncertainties/compare_central_to_electron_energy_down_8TeV_asym_bin_electron_channel.json
+++ b/config/plots/MET_uncertainties/compare_central_to_electron_energy_down_8TeV_asym_bin_electron_channel.json
@@ -1,0 +1,46 @@
+{
+	"class": "PlotConfig",
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/TTJet_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root",
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ], 
+    "file-aliases": [
+    	"TTJet",
+        "data"
+     ],
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMet/MET_2orMoreBtags",
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMetElectronEnDown/MET_2orMoreBtags"
+    ], 
+    "labels": [
+        "central", 
+        "electron energy down"
+    ], 
+    "output_folder": "plots/MET_uncertainties", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_central_MET_to_electron_energy_down_asym_bins_electron_channel_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.95, 1.05]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ (central, electron energy down) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(5 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.4]
+    ],
+    "rebin" : [
+    	[0.0, 27.0, 52.0, 87.0, 130.0, 172.0, 300]	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_uncertainties/compare_central_to_tau_energy_down_8TeV.json
+++ b/config/plots/MET_uncertainties/compare_central_to_tau_energy_down_8TeV.json
@@ -1,0 +1,41 @@
+{
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/TTJet_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root",
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ], 
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMet/MET_2orMoreBtags",
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMetTauEnDown/MET_2orMoreBtags"
+    ], 
+    "labels": [
+        "central", 
+        "$\\tau$ energy down"
+    ], 
+    "output_folder": "plots/MET_uncertainties", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_central_MET_to_tau_energy_down_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.5, 1.5]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ (central, $\\tau$ energy up) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(5 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.08]
+    ],
+    "rebin" : [
+    	1	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_uncertainties/compare_central_to_tau_energy_down_8TeV_asym_bin.json
+++ b/config/plots/MET_uncertainties/compare_central_to_tau_energy_down_8TeV_asym_bin.json
@@ -1,0 +1,46 @@
+{
+	"class": "PlotConfig",
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/TTJet_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root",
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ], 
+    "file-aliases": [
+    	"TTJet",
+        "data"
+     ],
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMet/MET_2orMoreBtags",
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMetTauEnDown/MET_2orMoreBtags"
+    ], 
+    "labels": [
+        "central", 
+        "$\\tau$ energy down"
+    ], 
+    "output_folder": "plots/MET_uncertainties", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_central_MET_to_tau_energy_down_asym_bins_electron_channel_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.9, 1.15]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ (central, $\\tau$ energy down) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(5 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.4]
+    ],
+    "rebin" : [
+    	[0.0, 27.0, 52.0, 87.0, 130.0, 172.0, 300]	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_uncertainties/compare_central_to_tau_energy_up_8TeV.json
+++ b/config/plots/MET_uncertainties/compare_central_to_tau_energy_up_8TeV.json
@@ -1,0 +1,41 @@
+{
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/TTJet_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root",
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ], 
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMet/MET_2orMoreBtags",
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMetTauEnUp/MET_2orMoreBtags"
+    ], 
+    "labels": [
+        "central", 
+        "$\\tau$ energy up"
+    ], 
+    "output_folder": "plots/MET_uncertainties", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_central_MET_to_tau_energy_up_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.5, 1.5]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ (central, $\\tau$ energy up) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(5 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.08]
+    ],
+    "rebin" : [
+    	1	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/MET_uncertainties/compare_central_to_tau_energy_up_8TeV_asym_bin.json
+++ b/config/plots/MET_uncertainties/compare_central_to_tau_energy_up_8TeV_asym_bin.json
@@ -1,0 +1,46 @@
+{
+	"class": "PlotConfig",
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/TTJet_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root",
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ], 
+    "file-aliases": [
+    	"TTJet",
+        "data"
+     ],
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMet/MET_2orMoreBtags",
+        "TTbar_plus_X_analysis/EPlusJets/Ref selection/MET/patType1CorrectedPFMetTauEnUp/MET_2orMoreBtags"
+    ], 
+    "labels": [
+        "central", 
+        "$\\tau$ energy up"
+    ], 
+    "output_folder": "plots/MET_uncertainties", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_central_MET_to_tau_energy_up_asym_bins_electron_channel_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.9, 1.15]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ (central, $\\tau$ energy up) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(5 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.4]
+    ],
+    "rebin" : [
+    	[0.0, 27.0, 52.0, 87.0, 130.0, 172.0, 300]	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/config/plots/ST_reco_gen_truth_comparison_8TeV.json
+++ b/config/plots/ST_reco_gen_truth_comparison_8TeV.json
@@ -1,0 +1,40 @@
+{
+    "command": "compare-hists", 
+    "files": [ 
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_6th_draft/8TeV/unfolding/unfolding_TTJets_8TeV.root"
+    ], 
+    "histograms": [
+        "unfolding_ST_analyser_electron_channel_patType1CorrectedPFMet/measured",
+        "unfolding_ST_analyser_electron_channel_patType1CorrectedPFMet/truth"
+    ], 
+    "labels": [
+        "measured", 
+        "truth"
+    ], 
+    "output_folder": "plots/TTJet_comparison", 
+    "output_format": ["pdf"], 
+    "name_prefix": ["ST"],
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0, 3]
+    ], 
+    "title": [
+        "Comparison of TTJets MC (measured, truth) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+        "$S_T$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 1000]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area /(10 GeV)"
+    ], 
+    "y_limits": [
+        [0, 0.05]
+    ],
+    "rebin" : [
+    	10	
+    ],
+    "colours": ["green", "yellow"]
+}

--- a/examples/Bin_Centers.py
+++ b/examples/Bin_Centers.py
@@ -11,12 +11,12 @@ import rootpy.plotting.root2matplotlib as rplt
 import matplotlib.pyplot as plt
 from array import array
 from rootpy import asrootpy
-
+import numpy as np
 if __name__ == '__main__':
     bins = array('d', [0, 25, 45, 70, 100, 1000])
     nbins = len(bins) - 1
     
-    inputFile = File('data/unfolding_merged_sub1.root', 'read')
+    inputFile = File('/storage/TopQuarkGroup/unfolding/unfolding_merged_sub1.root', 'read')
     h_truth_finebinned = inputFile.unfoldingAnalyserElectronChannel.truth
     h_truth = asrootpy(inputFile.unfoldingAnalyserElectronChannel.truth.Rebin(nbins, 'truth_new', bins))
     print 'old:', get_bin_centers(bins)
@@ -39,16 +39,21 @@ if __name__ == '__main__':
     
     h_truth_finebinned.SetFillStyle(0)
     h_truth_finebinned.Smooth(500)
+    x,y = list(h_truth_finebinned.x()), list(h_truth_finebinned.y())
+    bin_edges = np.array(list(h_truth_finebinned.xedges()))
+    bincenters = 0.5*(bin_edges[1:]+bin_edges[:-1])
     g_truth = Graph(h_truth)
 #    g_truth_new = Graph(len(h_truth), h_truth_new)
     g_truth_new.SetLineColor('red')
     g_truth_new.SetMarkerColor('red')
     h_truth_finebinned.axis().SetRange(0, 1000)
+    h_truth_finebinned.linecolor = 'orange'
     plt.figure(figsize=(16, 10), dpi=100)
     axes = plt.axes()
     rplt.errorbar(g_truth_new, label=r'corrected', emptybins=False)
     rplt.errorbar(g_truth, label=r'bin centre', emptybins=False)
-    rplt.hist(h_truth_finebinned, label=r'MC', stacked=False)
+    # rplt.hist(h_truth_finebinned, label=r'MC', stacked=False)
+    plt.plot(bincenters, y, '-')
     axes.set_xlim([0,300])
     plt.xlabel('$E_{\mathrm{T}}^{miss}$')
     plt.ylabel('Events')

--- a/tools/HistSet.py
+++ b/tools/HistSet.py
@@ -7,6 +7,8 @@ import sys
 from tools.plotting import Histogram_properties, make_shape_comparison_plot,\
     make_data_mc_comparison_plot
 from ROOT_utils import get_histogram_from_file
+import types
+from tools.hist_utilities import conditional_rebin
 
 class HistSet():
     '''
@@ -36,8 +38,13 @@ class HistSet():
         histogram_properties = Histogram_properties(plot_options)
         histogram_properties.name = file_name
         if plot_options.has_key('rebin') and plot_options['rebin'] > 1:
-            for hist in self.histograms:
-                hist.Rebin(plot_options['rebin'])
+            rebin = plot_options['rebin']
+            is_list = isinstance(rebin, types.ListType)
+            for i,hist in enumerate(self.histograms):
+                if is_list:
+                    self.histograms[i] = conditional_rebin(hist, rebin)
+                else:
+                    hist.rebin(rebin)
         
         colours = ['green', 'yellow', 'magenta', 'red', 'black']
         if plot_options.has_key('colours'):

--- a/tools/Unfolding.py
+++ b/tools/Unfolding.py
@@ -279,7 +279,7 @@ def get_unfold_histogram_tuple(
                 ttbar_xsection = 245.8,
                 luminosity = 19712,
                 load_fakes = False,
-                scale_to_lumi = False,
+                scale_to_lumi = True,
                 ):
     folder = None
     h_truth = None

--- a/tools/plotting.py
+++ b/tools/plotting.py
@@ -43,24 +43,18 @@ class Histogram_properties:
                 setattr( self, name, value )
 
 # prototype
-class Control_plot:
-    lumi = 5050
-    rebin = 1
-    histogram_properties = Histogram_properties()
-    channel = 'combined'
-    b_tag_bin = '2orMoreBtags'
+class PlotConfig:
+    '''
+        Class to read a JSON file and extract information from it.
+        It creates HistSets and plot_options, essentiall replacing the main
+        functionality of the bin/plot script.
+    '''
+    general_options = ['files', 'histograms', 'labels', 'plot_type', 'output_folder',
+                  'output_format', 'command', 'data_index', 'normalise',
+                  'show_ratio', 'show_stat_errors_on_mc', 'colours', 'name_prefix']
     
-    def __init__( self, control_region, qcd_control_region, histogram_files, **kwargs ):
-        self.control_region = control_region
-        self.qcd_control_region = qcd_control_region
-        self.histogram_files = histogram_files
-        
-        self.b_tag_bin = kwargs.pop( 'b_tag_bin', self.b_tag_bin )
-        self.lumi = kwargs.pop( 'lumi', self.lumi )
-        self.rebin = kwargs.pop( 'rebin', self.rebin )
-        self.histogram_properties = kwargs.pop( 'histogram_properties', self.histogram_properties )
-        self.channel = kwargs.pop( 'channel', self.channel )
-
+    def __init__( self, config_file, **kwargs ):
+        self.config_file = config_file
 
 def make_data_mc_comparison_plot( histograms = [],
                                  histogram_lables = [],
@@ -289,7 +283,8 @@ def make_shape_comparison_plot( shapes = [],
     # make copies in order not to mess with existing histograms
     shapes_ = deepcopy(shapes)
     # normalise as we are comparing shapes
-    for shape, colour in zip(shapes_, colours):
+    for shape, colour, label in zip(shapes_, colours, names):
+        shape.SetTitle(label)
         integral = shape.Integral()
         if integral > 0:
             shape.Sumw2()


### PR DESCRIPTION
- upgraded ```bin/plot```
  - added file-alias option (for compare-hists command only)
  - added name_prefix option
  - fixed legend bug for shape comparison
  - added PlotConfig skeleton: this is where the config reading capability of ```bin/plot``` will go
- changed lumi scale default for unfolding triplet from ```False``` to ```True``` (@jjacob)
- removed additional plot option (```-a```) from ```bin/x_04_all_vars``` (these are cross check plots, we don't need them in the default workflow)
- improved bin-centre example
- updated rootpy