### PR TITLE
[MRG] removed horizontal error bars from data marker in legend

### DIFF
--- a/examples/matplotlib_legend_manip.py
+++ b/examples/matplotlib_legend_manip.py
@@ -1,0 +1,14 @@
+'''
+Created on 29 Oct 2012
+
+@author: kreczko
+'''
+import matplotlib.pyplot as plt
+
+plt.errorbar( [0, 1, 2], [2, 3, 1], xerr = None, fmt = "s", label = "test 1" )
+plt.errorbar( [0, 1, 2], [3, 2, 4], yerr = 0.3, fmt = "o", label = "test 2" )
+plt.errorbar( [0, 1, 2], [1, 1, 3], xerr = 0.4, yerr = 0.3, fmt = "^", label = "test 3" )
+
+plt.legend(numpoints=1)
+plt.savefig('examples/plots/LegendManipulation.png')
+print 'Done'

--- a/examples/matplotlib_legend_manip.py
+++ b/examples/matplotlib_legend_manip.py
@@ -4,6 +4,8 @@ Created on 29 Oct 2012
 @author: kreczko
 '''
 import matplotlib.pyplot as plt
+from rootpy.plotting.hist import Hist
+import rootpy.plotting.root2matplotlib as rplt
 
 plt.errorbar( [0, 1, 2], [2, 3, 1], xerr = None, fmt = "s", label = "test 1" )
 plt.errorbar( [0, 1, 2], [3, 2, 4], yerr = 0.3, fmt = "o", label = "test 2" )
@@ -11,4 +13,13 @@ plt.errorbar( [0, 1, 2], [1, 1, 3], xerr = 0.4, yerr = 0.3, fmt = "^", label = "
 
 plt.legend(numpoints=1)
 plt.savefig('examples/plots/LegendManipulation.png')
+
+h1 = Hist(3, -0.5, 2.5)
+h1.Fill(0),h1.Fill(0),h1.Fill(0)
+h1.Fill(1),h1.Fill(1)
+h1.Fill(2)
+rplt.errorbar( h1, emptybins=False, xerr = None, fmt = "s", label = "rootpy" )
+
+plt.legend(numpoints=1)
+plt.savefig('examples/plots/LegendManipulation_rootpy.png')
 print 'Done'

--- a/examples/xkcd.py
+++ b/examples/xkcd.py
@@ -1,0 +1,101 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from rootpy.plotting import Hist
+import rootpy.plotting.root2matplotlib as rplt
+from config import CMS
+
+with plt.xkcd():
+    # Based on "Stove Ownership" from XKCD by Randall Monroe
+    # http://xkcd.com/418/
+
+    fig = plt.figure()
+    ax = fig.add_axes((0.1, 0.2, 0.8, 0.7))
+    ax.spines['right'].set_color('none')
+    ax.spines['top'].set_color('none')
+    plt.xticks([])
+    plt.yticks([])
+    ax.set_ylim([-30, 10])
+
+    data = np.ones(100)
+    data[70:] -= np.arange(30)
+
+    plt.annotate(
+        'THE DAY I REALIZED\nI COULD COOK BACON\nWHENEVER I WANTED',
+        xy=(70, 1), arrowprops=dict(arrowstyle='->'), xytext=(15, -10))
+
+    plt.plot(data)
+
+    plt.xlabel('time')
+    plt.ylabel('my overall health')
+    fig.text(
+        0.5, 0.05,
+        '"Stove Ownership" from xkcd by Randall Monroe',
+        ha='center')
+
+    # Based on "The Data So Far" from XKCD by Randall Monroe
+    # http://xkcd.com/373/
+
+    fig = plt.figure()
+    ax = fig.add_axes((0.1, 0.2, 0.8, 0.7))
+    ax.bar([-0.125, 1.0-0.125], [0, 100], 0.25)
+    ax.spines['right'].set_color('none')
+    ax.spines['top'].set_color('none')
+    ax.xaxis.set_ticks_position('bottom')
+    ax.set_xticks([0, 1])
+    ax.set_xlim([-0.5, 1.5])
+    ax.set_ylim([0, 110])
+    ax.set_xticklabels(['CONFIRMED BY\nEXPERIMENT', 'REFUTED BY\nEXPERIMENT'])
+    plt.yticks([])
+
+    plt.title("CLAIMS OF SUPERNATURAL POWERS")
+
+    fig.text(
+        0.5, 0.05,
+        '"The Data So Far" from xkcd by Randall Monroe',
+        ha='center')
+
+plt.savefig('examples/plots/xkcd.png')
+
+with plt.xkcd():
+    
+    CMS.axis_label_major['labelsize'] = 40
+    CMS.title['fontsize'] = 40
+    # create a normal distribution
+    mu, sigma = 100, 15
+    x = mu + sigma * np.random.randn(10000)
+    
+    # create a histogram with 100 bins from 40 to 160
+    h = Hist(100, 40, 160)
+    
+    # fill the histogram with our distribution
+    map(h.Fill, x)
+    
+    # normalize the histogram
+    h /= h.Integral()
+    
+    # set visual attributes
+    h.SetFillStyle('solid')
+    h.SetFillColor('green')
+    h.SetLineColor('green')
+    
+    # the histogram of the data
+    plt.figure(figsize=(16, 12), dpi=200)
+    axes = plt.axes()
+    axes.minorticks_on()
+    rplt.hist(h, label=r'$\epsilon$(Something complicated)', alpha = 0.7)
+    plt.xlabel('Discovery', CMS.x_axis_title)
+    plt.ylabel('Probability of a discovery', CMS.y_axis_title)
+    #plt.title(r'combined, CMS Preliminary, $\mathcal{L}$ = 5.1 fb$^{-1}$ at $\sqrt{s}$ = 7 TeV',
+    #          fontsize=30,
+    #          verticalalignment='bottom')
+    #plt.title(r'e+jets, CMS Preliminary, $\mathcal{L}$ = 5.1 fb$^{-1}$ at $\sqrt{s}$ = 7 TeV',
+    #fontsize=30,
+    #          verticalalignment='bottom')
+    plt.title(r'$\mu$+jets, CMS Preliminary, $\mathcal{L}$ = 5.1 fb$^{-1}$ at $\sqrt{s}$ = 7 TeV', CMS.title)
+    # plt.annotate('look at this', xy=(60, 0.005), xytext=(50, 0.01),
+    #            arrowprops=dict(facecolor='black', shrink=0.05))
+    plt.tick_params(**CMS.axis_label_major)
+    plt.tick_params(**CMS.axis_label_minor)
+    plt.legend(numpoints=1, prop=CMS.legend_properties)
+    plt.tight_layout()
+plt.savefig('examples/plots/xkcd2.png')

--- a/src/HLT_scripts_for_Sergeys_thesis/make_HLT_plots_Sergey.py
+++ b/src/HLT_scripts_for_Sergeys_thesis/make_HLT_plots_Sergey.py
@@ -141,7 +141,7 @@ def make_jet_response_comparison_plot(input_files, response):
     }
     counter = 0
     for jet_response_name, jet_response in sorted(jet_responses.iteritems()):
-        rplt.errorbar(jet_response, xerr=False, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
+        rplt.errorbar(jet_response, xerr=None, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
             markerfacecolor = marker_face_colours[counter], markeredgecolor = marker_edge_colours[counter], ecolor = marker_edge_colours[counter], ms=15, mew=3, lw = 2)
         jet_response_name_list.append(jet_response_name)
         counter += 1

--- a/src/HLT_scripts_for_Sergeys_thesis/make_jet_response_plot_pt_bins.py
+++ b/src/HLT_scripts_for_Sergeys_thesis/make_jet_response_plot_pt_bins.py
@@ -141,7 +141,7 @@ def make_jet_response_comparison_plot(input_files, response):
     }
     counter = 0
     for jet_response_name, jet_response in sorted(jet_responses.iteritems()):
-        rplt.errorbar(jet_response, xerr=False, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
+        rplt.errorbar(jet_response, xerr=None, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
             markerfacecolor = marker_face_colours[counter], markeredgecolor = marker_edge_colours[counter], ecolor = marker_edge_colours[counter], ms=15, mew=3, lw = 2)
         jet_response_name_list.append(jet_response_name)
         counter += 1

--- a/src/HLT_scripts_for_Sergeys_thesis/make_jet_response_plots_correction_levels.py
+++ b/src/HLT_scripts_for_Sergeys_thesis/make_jet_response_plots_correction_levels.py
@@ -141,7 +141,7 @@ def make_jet_response_comparison_plot(input_files, response):
     }
     counter = 0
     for jet_response_name, jet_response in jet_responses.iteritems():
-        rplt.errorbar(jet_response, xerr=False, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
+        rplt.errorbar(jet_response, xerr=None, emptybins=True, axes=ax0, marker = markers[counter], fillstyle = fill_styles[counter],
             markerfacecolor = marker_face_colours[counter], markeredgecolor = marker_edge_colours[counter], ecolor = marker_edge_colours[counter], ms=15, mew=3, lw = 2)
         jet_response_name_list.append(jet_response_name)
         counter += 1

--- a/src/cross_section_measurement/04_make_plots_matplotlib.py
+++ b/src/cross_section_measurement/04_make_plots_matplotlib.py
@@ -516,11 +516,11 @@ def plot_central_and_systematics( channel, systematics, exclude = [], suffix = '
             colour_number = 42
         hist_data_systematic.SetMarkerColor( colour_number )
         if 'PDF' in systematic:
-            rplt.errorbar( hist_data_systematic, axes = axes, label = systematic.replace( 'Weights_', ' ' ), xerr = False )
+            rplt.errorbar( hist_data_systematic, axes = axes, label = systematic.replace( 'Weights_', ' ' ), xerr = None )
         elif met_type in systematic:
-            rplt.errorbar( hist_data_systematic, axes = axes, label = met_systematics_latex[systematic.replace( met_type, '' )], xerr = False )
+            rplt.errorbar( hist_data_systematic, axes = axes, label = met_systematics_latex[systematic.replace( met_type, '' )], xerr = None )
         else:
-            rplt.errorbar( hist_data_systematic, axes = axes, label = measurements_latex[systematic], xerr = False )
+            rplt.errorbar( hist_data_systematic, axes = axes, label = measurements_latex[systematic], xerr = None )
             
     plt.legend( numpoints = 1, loc = 'center right', prop = {'size':25}, ncol = 2 )
     label, channel_label = get_cms_labels( channel )

--- a/src/cross_section_measurement/04_make_plots_matplotlib.py
+++ b/src/cross_section_measurement/04_make_plots_matplotlib.py
@@ -335,7 +335,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = True
         hist_data_with_systematics.visible = True
         rplt.errorbar( hist_data_with_systematics, axes = axes, label = 'do_not_show', xerr = None, capsize = 0, elinewidth = 2, zorder = len( histograms ) + 1 )
     rplt.errorbar( hist_data, axes = axes, label = 'do_not_show', xerr = None, capsize = 15, capthick = 3, elinewidth = 2, zorder = len( histograms ) + 2 )
-    rplt.errorbar( hist_data, axes = axes, label = 'data', xerr = False, yerr = False, zorder = len( histograms ) + 3 )  # this makes a nicer legend entry
+    rplt.errorbar( hist_data, axes = axes, label = 'data', xerr = None, yerr = False, zorder = len( histograms ) + 3 )  # this makes a nicer legend entry
 
     if show_before_unfolding:
         rplt.errorbar( hist_measured, axes = axes, label = 'data (before unfolding)', xerr = None, zorder = len( histograms ) )

--- a/src/cross_section_measurement/06_compare_energies.py
+++ b/src/cross_section_measurement/06_compare_energies.py
@@ -119,8 +119,8 @@ def draw_result( result, axes ):
     mcatnlo.SetLineColor( kMagenta + 3 )
     
     
-    rplt.errorbar( graph, xerr = False, emptybins = False, axes = axes, elinewidth = 2, capsize = 10, capthick = 2, zorder = 6)
-    rplt.errorbar( graph_with_systematics, xerr = False, emptybins = False, axes = axes, elinewidth = 2, capsize = 0, zorder = 5, label = 'unfolded data')
+    rplt.errorbar( graph, xerr = None, emptybins = False, axes = axes, elinewidth = 2, capsize = 10, capthick = 2, zorder = 6)
+    rplt.errorbar( graph_with_systematics, xerr = None, emptybins = False, axes = axes, elinewidth = 2, capsize = 0, zorder = 5, label = 'unfolded data')
     rplt.hist( madgraph, axes = axes, label = 'MADGRAPH', zorder = 1 )
     rplt.hist( powheg, axes = axes, label = 'POWHEG', zorder = 2 )
     rplt.hist( mcatnlo, axes = axes, label = 'MCATNLO', zorder = 3 )

--- a/src/cross_section_measurement/make_control_plots.py
+++ b/src/cross_section_measurement/make_control_plots.py
@@ -202,6 +202,9 @@ def make_plot( channel, x_axis_title, y_axis_title,
     histogram_properties.x_limits = x_limits
     histogram_properties.y_limits = y_limits
     histogram_properties.y_max_scale = y_max_scale
+    histogram_properties.xerr = None
+    # workaround for rootpy issue #638
+    histogram_properties.emptybins = True
     if b_tag_bin:
         histogram_properties.additional_text = channel_latex[channel] + ', ' + b_tag_bins_latex[b_tag_bin]
     else:

--- a/src/lepton_scale_factors/read_BLT_ntuple.py
+++ b/src/lepton_scale_factors/read_BLT_ntuple.py
@@ -311,7 +311,7 @@ def plot_efficiencies(efficiency_data, efficiency_mc, scale_factor,
     ax0.yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
     
     rplt.errorbar(efficiency_data, xerr=True, emptybins=True, axes=ax0)
-    rplt.errorbar(efficiency_mc, xerr=False, emptybins=True, axes=ax0)
+    rplt.errorbar(efficiency_mc, xerr=None, emptybins=True, axes=ax0)
     
     ax0.set_xlim(x_limits)
     

--- a/src/search/validate_systematic_method.py
+++ b/src/search/validate_systematic_method.py
@@ -27,7 +27,7 @@ def draw_pair(constructed, real, systematic):
     constructed.SetTitle('constructed')
     real.SetTitle('real')
     
-    rplt.errorbar(constructed, xerr=False, emptybins=False, axes=axes)
+    rplt.errorbar(constructed, xerr=None, emptybins=False, axes=axes)
     rplt.hist(real)
     
     plt.xlabel('MET [GeV]', CMS.x_axis_title)

--- a/src/unfolding_tests/analyze_unfolding_pulls.py
+++ b/src/unfolding_tests/analyze_unfolding_pulls.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
 	ax0.xaxis.labelpad = 11
 	
 	rplt.errorbar(graph, xerr=True, emptybins=True, axes=ax0, marker = 'o', ms = 15, mew=3, lw = 2)
-	rplt.errorbar(graphSpread, xerr=False, yerr=False, axes=ax0, linestyle='-', marker = 's', ms = 10, mew=1, lw = 2)
+	rplt.errorbar(graphSpread, xerr=None, yerr=False, axes=ax0, linestyle='-', marker = 's', ms = 10, mew=1, lw = 2)
 
 	for output_format in output_formats:
 		print output_folder_base

--- a/src/zprime_analysis/make_control_region_plots.py
+++ b/src/zprime_analysis/make_control_region_plots.py
@@ -98,7 +98,7 @@ def make_control_region_data_mc_comparision(histograms, histogram_name,
     axes = plt.axes()
     
     rplt.hist(stack, stacked=True, axes=axes)
-    rplt.errorbar(data, xerr=False, emptybins=False, axes=axes)
+    rplt.errorbar(data, xerr=None, emptybins=False, axes=axes)
     
     plt.xlabel(x_label, CMS.x_axis_title)
     plt.ylabel(y_label, CMS.y_axis_title)

--- a/tools/plotting.py
+++ b/tools/plotting.py
@@ -43,6 +43,10 @@ class Histogram_properties:
     ratio_y_title = 'I am the ratio'
     legend_color = False
     y_max_scale = 1.2
+    xerr = False
+    #If True (the default) then plot bins with zero content otherwise only
+    #    show bins with nonzero content.
+    emptybins = False
     
     
     def __init__( self, dictionary = {} ):
@@ -143,7 +147,8 @@ def make_data_mc_comparison_plot( histograms = [],
     # then the MC error (z = len(histograms_) + 1) and finally the data 
     # (z = len(histograms_) + 2)
     rplt.hist( stack, stacked = True, axes = axes, zorder = 1 )
-    rplt.errorbar( data, xerr = None, emptybins = False, axes = axes, 
+    rplt.errorbar( data, emptybins = histogram_properties.emptybins, axes = axes,
+                   xerr = histogram_properties.xerr,
                    elinewidth = 2, capsize = 10, capthick = 2, 
                    zorder = len(histograms_) + 2 )
     
@@ -197,7 +202,8 @@ def make_data_mc_comparison_plot( histograms = [],
         set_labels( plt, histogram_properties, show_x_label = True, show_title = False )
         plt.ylabel( r'$\frac{\mathrm{data}}{\mathrm{pred.}}$', CMS.y_axis_title )
         ax1.yaxis.set_label_coords(-0.115, 0.8)
-        rplt.errorbar( ratio, xerr = True, emptybins = False, axes = ax1 )
+        rplt.errorbar( ratio, emptybins = histogram_properties.emptybins, axes = ax1,
+                       xerr = histogram_properties.xerr, )
         if len( x_limits ) == 2:
             ax1.set_xlim( xmin = x_limits[0], xmax = x_limits[1] )
         if len( histogram_properties.ratio_y_limits ) == 2:
@@ -282,7 +288,9 @@ def make_control_region_comparison( control_region_1, control_region_2,
     adjust_ratio_ticks(ax1.yaxis, n_ticks = 3)
     set_labels( plt, histogram_properties, show_x_label = True, show_title = False )
     plt.ylabel( '(1)/(2)', CMS.y_axis_title )
-    rplt.errorbar( ratio, xerr = True, emptybins = False, axes = ax1 )
+    rplt.errorbar( ratio, xerr = True,
+                   emptybins = histogram_properties.emptybins,
+                   axes = ax1 )
     if len( x_limits ) == 2:
         ax1.set_xlim( xmin = x_limits[0], xmax = x_limits[1] )
     if len( histogram_properties.ratio_y_limits ) == 2:
@@ -365,7 +373,7 @@ def make_shape_comparison_plot( shapes = [],
     #add error bars
     graphs = spread_x(shapes_, list(shapes_[0].xedges()))
     for graph in graphs:
-        rplt.errorbar( graph, axes = axes, xerr = False,)
+        rplt.errorbar( graph, axes = axes )
 
     adjust_axis_limits(axes, histogram_properties, shapes_)
     if make_ratio:
@@ -381,7 +389,9 @@ def make_shape_comparison_plot( shapes = [],
             plt.ylabel( '(1)/(2)', CMS.y_axis_title )
         for ratio in ratios:
             ratio.SetMarkerSize( 2 )
-            rplt.errorbar( ratio, xerr = True, emptybins = False, axes = ax1 )
+            rplt.errorbar( ratio, xerr = True,
+                           emptybins = histogram_properties.emptybins,
+                           axes = ax1 )
         if len( histogram_properties.x_limits ) == 2:
             ax1.set_xlim( xmin = histogram_properties.x_limits[0], 
                           xmax = histogram_properties.x_limits[1] )
@@ -419,7 +429,8 @@ def make_plot( histogram, histogram_label, histogram_properties = Histogram_prop
     axes = plt.axes()
     
     if draw_errorbar:
-        rplt.errorbar( histogram, xerr = False, emptybins = False, axes = axes, elinewidth = 2, capsize = 10, capthick = 2 )
+        rplt.errorbar( histogram, emptybins = histogram_properties.emptybins,
+                       axes = axes, elinewidth = 2, capsize = 10, capthick = 2 )
     else:
         rplt.hist( histogram )
     
@@ -508,7 +519,7 @@ def compare_measurements( models = {}, measurements = {},
         histogram.markerstyle = next( markercycler )
         histogram.color = next( colorcycler )
         rplt.errorbar( histogram, axes = axes, label = label ,
-                       yerr = show_measurement_errors, xerr = False )
+                       yerr = show_measurement_errors )
     
     set_labels( plt, histogram_properties, axes = axes )
 

--- a/tools/plotting.py
+++ b/tools/plotting.py
@@ -143,7 +143,7 @@ def make_data_mc_comparison_plot( histograms = [],
     # then the MC error (z = len(histograms_) + 1) and finally the data 
     # (z = len(histograms_) + 2)
     rplt.hist( stack, stacked = True, axes = axes, zorder = 1 )
-    rplt.errorbar( data, xerr = False, emptybins = False, axes = axes, 
+    rplt.errorbar( data, xerr = None, emptybins = False, axes = axes, 
                    elinewidth = 2, capsize = 10, capthick = 2, 
                    zorder = len(histograms_) + 2 )
     

--- a/tools/toy_mc.py
+++ b/tools/toy_mc.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
     axes.tick_params(which='major', labelsize=15, length=8)
     axes.tick_params(which='minor', length=4)
     rplt.hist(h_new, axes=axes)
-    rplt.errorbar(h_data, xerr=False, emptybins=False, axes=axes)
+    rplt.errorbar(h_data, emptybins=False, axes=axes)
     plt.xlabel('Mass', position=(1., 0.), ha='right')
     plt.ylabel('Events', position=(0., 1.), va='top')
     plt.legend(numpoints=1)


### PR DESCRIPTION
As usual the devil is in the detail. When plots are drawn the parameter ```xerr``` determines the size of the x-error bar. In many cases it was set to ```False``` which is equivalent to 0. Therefore the legend was showing horizontal error bars.

The fix is simple: replace ```xerr = False``` with ```xerr = None```. 