### PR TITLE
Final changes for PAS

### DIFF
--- a/config/latex_labels.py
+++ b/config/latex_labels.py
@@ -128,10 +128,9 @@ measurements_latex = {
     'SingleTop_cross_section+': 'Single top cross section \ensuremath{+1\sigma}',
     'luminosity-': 'Luminosity \ensuremath{-1\sigma}',
     'luminosity+': 'Luminosity \ensuremath{+1\sigma}',
-    # 'massdown': '\ensuremath{t\\bar{t}} (top mass down)',
-    # 'massup': '\ensuremath{t\\bar{t}} (top mass up)',
-    'massdown': 'Top mass down',
-    'massup': 'Top mass up',
+    'massdown': '$\mathrm{m}_{\mathrm{t}}$=169.5 GeV',
+    'massup': '$\mathrm{m}_{\mathrm{t}}$=175.5 GeV',
+
 }
 
 met_systematics_latex = {

--- a/src/cross_section_measurement/make_control_plots_fromTrees.py
+++ b/src/cross_section_measurement/make_control_plots_fromTrees.py
@@ -373,6 +373,10 @@ def make_plot( channel, x_axis_title, y_axis_title,
     if ratio_y_limits:
         histogram_properties.ratio_y_limits = ratio_y_limits
 
+
+    if branchName in ['NJets', 'NBJets', 'NBJetsNoWeight']:
+        histogram_properties.integerXVariable = True
+
     # if normalise_to_fit:
     #     histogram_properties.mc_error = get_normalisation_error( normalisation )
     #     histogram_properties.mc_errors_label = 'fit uncertainty'
@@ -473,7 +477,7 @@ if __name__ == '__main__':
             }
     preliminary = True
     useQCDControl = True
-    showErrorBandOnRatio = True
+    showErrorBandOnRatio = False
     b_tag_bin = '2orMoreBtags'
     norm_variable = 'MET'
     # comment out plots you don't want

--- a/tools/plotting.py
+++ b/tools/plotting.py
@@ -45,6 +45,7 @@ class Histogram_properties:
     legend_color = False
     y_max_scale = 1.2
     xerr = False
+    integerXVariable = False
     #If True (the default) then plot bins with zero content otherwise only
     #    show bins with nonzero content.
     emptybins = False
@@ -322,6 +323,9 @@ def make_data_mc_comparison_plot( histograms = [],
 
         # dynamic tick placement
         adjust_ratio_ticks(ax1.yaxis, n_ticks = 3, y_limits = histogram_properties.ratio_y_limits)
+
+        if histogram_properties.integerXVariable :
+            ax1.tick_params(axis='x',which='minor',bottom='off',top='off')
 
         if systematics_for_ratio != None:
             plusErrors = [x+1 for x in systematics_for_ratio]


### PR DESCRIPTION
-Labels of top mass variation
-Tick marks on NJets ratio plot
-Cosmetics of result plots
Can now use custom dashes/line styles (rather than one of the four offered by matplotlib by default).
Also ensure central TTJet MC is drawn last, as it looks better.