### PR TITLE
Produce combined response matrices.

### DIFF
--- a/experimental/BLTUnfold/produceUnfoldingHistograms.py
+++ b/experimental/BLTUnfold/produceUnfoldingHistograms.py
@@ -476,6 +476,20 @@ def main():
                     pass
                 pass
             pass
+
+            # Done all channels, now combine the two channels, and output to the same file
+            for path, dirs, objects in out.walk():
+                if 'electron' in path:
+                    outputDir = out.mkdir(path.replace('electron','COMBINED'))
+                    outputDir.cd()
+                    for h in objects:
+                        h_e = out.Get(path+'/'+h)
+                        h_mu = out.Get(path.replace('electron','muon')+'/'+h)
+                        h_comb = (h_e + h_mu).Clone(h)
+                        h_comb.Write()
+                    pass
+                pass
+            pass
         pass
 
 if __name__ == '__main__':


### PR DESCRIPTION
Combine the response matrices/unfolding histograms for the two channels when they are produced.

This is already done on the fly later on, when combining before unfolding in 02, but it will be easier for e.g. 00_pick_bins and for choosing tau value if the response matrices are already combined.