### PR TITLE
Produce combined response matrices after closing and repopening file.

### DIFF
--- a/experimental/BLTUnfold/produceUnfoldingHistograms.py
+++ b/experimental/BLTUnfold/produceUnfoldingHistograms.py
@@ -476,7 +476,9 @@ def main():
                     pass
                 pass
             pass
+        pass
 
+        with root_open( outputFileName, 'update') as out:
             # Done all channels, now combine the two channels, and output to the same file
             for path, dirs, objects in out.walk():
                 if 'electron' in path:
@@ -490,7 +492,6 @@ def main():
                     pass
                 pass
             pass
-        pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Bug in current version - Even though all histograms are written to the file, when they are accessed, the wrong histogram can be picked up...not sure why.  Maybe because histograms for different variables/channels have the same names but end up in different directories.

Fix by closing the file first, and reopening...