### PR TITLE
Unfolding closure

### DIFF
--- a/bin/create_unfolding_pulls_on_DICE
+++ b/bin/create_unfolding_pulls_on_DICE
@@ -54,8 +54,8 @@ def main():
     centre_of_mass_energy = options.com
     config = XSectionConfig(centre_of_mass_energy)
     method = options.method
-    n_toy_data = options.n_toy_data
-    output_folder = 'data/pull_data/'
+    n_toy_data = int( options.n_toy_data )
+    output_folder = 'data/pull_data'
 
     do_best_tau = options.do_best_tau
     tau_range = []
@@ -89,7 +89,7 @@ def main():
     if do_best_tau:
         n_sub_jobs += len(samples) * len(variables) * len(channels)
 
-    condor_job = job.Condor(n_sub_jobs, -1, request_memory=50)
+    condor_job = job.Condor(n_sub_jobs, -1, request_memory=10)
     condor_job.add_job( pull_job )
 
     condor_job.submit()

--- a/bin/create_unfolding_pulls_on_DICE
+++ b/bin/create_unfolding_pulls_on_DICE
@@ -29,6 +29,8 @@ def main():
                       help="Variables to be analysed, separated by commas")
     parser.add_option("-i", "--input_directory", dest="input_directory",
                       help="Toy MC input directory", default='data/toy_mc/')
+    parser.add_option("-n", dest="n_toy_data",
+                      help="Number of toy datasets to analyse", default=3000)
     parser.add_option("--scan_tau", dest="scan_tau", action='store_true',
                       help="Produce unfolding pulls for a range of tau values", default=False)
     parser.add_option("--tau_min", dest="tau_min",
@@ -52,7 +54,7 @@ def main():
     centre_of_mass_energy = options.com
     config = XSectionConfig(centre_of_mass_energy)
     method = options.method
-    n_toy_data = 10000
+    n_toy_data = options.n_toy_data
     output_folder = 'data/pull_data/'
 
     do_best_tau = options.do_best_tau

--- a/bin/dice_01
+++ b/bin/dice_01
@@ -2,7 +2,7 @@
 echo "Recreating Config Files (Just in case you forgot...)"
 python src/cross_section_measurement/create_measurement.py
 echo "Tarring DailyPythonScripts..."
-tar -cf dps.tar ../DailyPythonScripts/ --exclude ../DailyPythonScripts/data --exclude ../DailyPythonScripts/plots --exclude ../DailyPythonScripts/tables  --exclude ../DailyPythonScripts/jobs --exclude ../DailyPythonScripts/dps.tar
+tar -cf dps.tar ../DailyPythonScripts/ --exclude ../DailyPythonScripts/data --exclude ../DailyPythonScripts/plots --exclude ../DailyPythonScripts/tables  --exclude ../DailyPythonScripts/jobs --exclude ../DailyPythonScripts/unfolding --exclude ../DailyPythonScripts/dps.tar
 echo "Submitting jobs to DICE..."
 condor_submit experimental/condor/01b/01_fit.description
 echo "Done."

--- a/condor/job_template
+++ b/condor/job_template
@@ -3,7 +3,7 @@ Universe = vanilla
 Output = jobs/%today%/logs/job.$(cluster).$(process).out
 Error = jobs/%today%/logs/job.$(cluster).$(process).err
 Log = jobs/%today%/logs/job.$(cluster).$(process).log
-arguments = %pkl_file% $(cluster) $(process) %n_jobs_to_split%
+arguments = %pkl_file% $(cluster) $(process) %n_jobs_to_split% %dir_of_dps_on_hdfs% 
 
 transfer_input_files = %input_files%
 should_transfer_files = YES

--- a/condor/jobtypes/unfolding_pull_job_new.py
+++ b/condor/jobtypes/unfolding_pull_job_new.py
@@ -32,16 +32,16 @@ class UnfoldingPullJob(Job):
         self.all_tau_values = tau_values
         self.cross_section_config = XSectionConfig(self.centre_of_mass)
 
-        self.additional_input_files = []
-        for sample in self.all_samples:
-            additional_input_file_template = '{directory}/toy_mc_{sample}_N_{n}_{com}TeV.root'
-            additional_input_file = additional_input_file_template.format(
-                                                                    directory = self.input_file_directory,
-                                                                    sample = sample,
-                                                                    n = self.n_toy_data,
-                                                                    com = self.centre_of_mass
-                                                                    )
-            self.additional_input_files.append(additional_input_file)
+        # self.additional_input_files = []
+        # for sample in self.all_samples:
+        #     additional_input_file_template = '{directory}/toy_mc_{sample}_N_{n}_{com}TeV.root'
+        #     additional_input_file = additional_input_file_template.format(
+        #                                                             directory = self.input_file_directory,
+        #                                                             sample = sample,
+        #                                                             n = self.n_toy_data,
+        #                                                             com = self.centre_of_mass
+        #                                                             )
+        #     self.additional_input_files.append(additional_input_file)
 
     def run(self):
         '''
@@ -95,7 +95,7 @@ class UnfoldingPullJob(Job):
 
                         input_file_name = self.get_input_file_name( self.input_file_directory, sample, self.centre_of_mass, self.n_toy_data)
                         j.input_file_name = input_file_name
-                        j.additional_input_files = [input_file_name]
+                        # j.additional_input_files = [input_file_name]
 
                         subjobs.append(j)
         if len(subjobs) != n :

--- a/condor/jobtypes/unfolding_pull_job_new.py
+++ b/condor/jobtypes/unfolding_pull_job_new.py
@@ -50,7 +50,7 @@ class UnfoldingPullJob(Job):
         import src.unfolding_tests.create_unfolding_pull_data as pull
         from tools.ROOT_utils import set_root_defaults
         set_root_defaults(msg_ignore_level=3001)
-        pull.create_unfolding_pull_data(self.input_file_name,
+        pulls_file_name = pull.create_unfolding_pull_data(self.input_file_name,
                                         self.method,
                                         self.channel_to_run,
                                         self.centre_of_mass,
@@ -61,6 +61,12 @@ class UnfoldingPullJob(Job):
                                         self.output_folder,
                                         self.tau_value_to_run
                                         )
+
+        # import src.unfolding_tests.make_unfolding_pull_plots as plots
+        # plots.makeAllPlots(
+        #     file_name = pulls_file_name,
+        #     output_directory_base = 'plots/unfolding_pulls'
+        #     )
 
     def split(self, n):
         subjobs = []
@@ -99,7 +105,8 @@ class UnfoldingPullJob(Job):
 
                         subjobs.append(j)
         if len(subjobs) != n :
-            print ('Warning : Did not get the expected number of subjobs')
+            print ('Warning in unfolding_pull_job_new split() : Did not get the expected number of subjobs')
+            print ('n :',n,'subjobs :',len(subjobs))
         return subjobs
 
     def tar_output(self, job_id, subjob_id):

--- a/condor/prepare_dps.sh
+++ b/condor/prepare_dps.sh
@@ -8,7 +8,10 @@ if [ -f "dps.tar" ]; then
 fi
 echo "... creating tar file (dps.tar)"
 mkdir -p jobs
-tar -cf dps.tar bin condor config jobs src tools setup.sh environment.sh \
-setup_with_conda.sh environment_conda.sh experimental \
+tar -zcf dps.tar bin condor config jobs src tools setup.sh environment.sh \
+setup_with_conda.sh environment_conda.sh experimental data/toy_mc \
 --exclude="*.pyc" --exclude="jobs/*/logs" \
 --exclude "*.tar" --exclude="config/unfolding" --exclude="experimental/topReco"
+
+hadoop fs -mkdir -p $1
+hadoop fs -copyFromLocal dps.tar $1

--- a/condor/run.sh
+++ b/condor/run.sh
@@ -19,6 +19,8 @@ git checkout ${git_branch}
 echo "... setting up git submodules"
 >&2 echo "... setting up git submodules"
 time git submodule init && git submodule update
+echo "... copying dps.tar from hdfs"
+hadoop fs -copyToLocal $5/dps.tar ${_CONDOR_JOB_IWD}/dps.tar
 echo "... extracting ${_CONDOR_JOB_IWD}/dps.tar on top"
 tar -xf ${_CONDOR_JOB_IWD}/dps.tar --overwrite
 echo "... running setup routine"
@@ -32,3 +34,6 @@ echo "DailyPythonScripts are set up"
 echo "Running payload"
 >&2 echo "Running payload"
 time env PATH=$PATH PYTHONPATH=$PYTHONPATH ./condor/run_job $@
+
+echo "Cleaning up files"
+rm ${_CONDOR_JOB_IWD}/dps.tar

--- a/condor/run_job
+++ b/condor/run_job
@@ -36,7 +36,7 @@ for f in additional_input_files:
     file_name = f.split('/')[-1]
     folder = f.replace(file_name, '')
     make_folder_if_not_exists(folder)
-    shutil.copyfile(base_dir + '/' + file_name, f)
+    shutil.copyfile(f, base_dir + '/' + file_name)
 
 subjobs = job.split(n_jobs)
 # pick the correct subjob

--- a/config/cross_section_config.py
+++ b/config/cross_section_config.py
@@ -98,7 +98,7 @@ class XSectionConfig():
             self.path_to_unfolding_histograms = self.path_to_files + 'unfolding/'
         else:
             self.path_to_files = self.current_analysis_path + str( self.centre_of_mass_energy ) + 'TeV/25ns/'
-            self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/25ns/'
+            self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/25ns/15_02_16/'
 
         path_to_files = self.path_to_files
         path_to_unfolding_histograms = self.path_to_unfolding_histograms

--- a/config/cross_section_config.py
+++ b/config/cross_section_config.py
@@ -98,7 +98,7 @@ class XSectionConfig():
             self.path_to_unfolding_histograms = self.path_to_files + 'unfolding/'
         else:
             self.path_to_files = self.current_analysis_path + str( self.centre_of_mass_energy ) + 'TeV/25ns/'
-            self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/25ns/15_02_16/'
+            self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/25ns/'
 
         path_to_files = self.path_to_files
         path_to_unfolding_histograms = self.path_to_unfolding_histograms
@@ -612,7 +612,6 @@ class XSectionConfig():
 "ST" : 0.00626425547204,
 "MET" : 0.000143301257024,
 "HT" : 0.00468724990318,
-
 
 
             'bjets_pt': 0.,

--- a/src/BLTUnfold/produceUnfoldingHistograms.py
+++ b/src/BLTUnfold/produceUnfoldingHistograms.py
@@ -22,6 +22,9 @@ class channel:
         pass
     pass
 
+def calculateTopPtWeight( lepTopPt, hadTopPt ):
+    return max ( ( 1 + ( branch('lepTopPt_parton') - 100 ) / 500 ) * ( 1 + ( branch('hadTopPt_parton') - 100 ) / 500 ) , 0.1 )
+
 def getFileName( com, sample, measurementConfig ) :
 
     fileNames = {
@@ -334,6 +337,11 @@ def main():
                         genWeight *= branch('genWeight_%i' % meWeight)
                         offlineWeight *= branch('genWeight_%i' % meWeight)
                         pass
+
+                    if options.applyTopPtReweighting:
+                        ptWeight = calculateTopPtWeight( branch('lepTopPt_parton'), branch('hadTopPt_parton'))
+                        offlineWeight *= ptWeight
+                        genWeight *= ptWeight
 
                     for channel in channels:
                         # Generator level selection

--- a/src/BLTUnfold/runJobsCrab.py
+++ b/src/BLTUnfold/runJobsCrab.py
@@ -7,6 +7,8 @@ jobs = [
         '--centreOfMassEnergy 13 -f',
 
         '--centreOfMassEnergy 13 -s central',
+        '--centreOfMassEnergy 13 -s central --topPtReweighting'
+
         '--centreOfMassEnergy 13 -s amcatnlo',
         '--centreOfMassEnergy 13 -s madgraph',
         '--centreOfMassEnergy 13 -s herwigpp',

--- a/src/BLTUnfold/submitBLTUnfold.description
+++ b/src/BLTUnfold/submitBLTUnfold.description
@@ -15,4 +15,4 @@ request_memory=500
 # use the ENV that is provided
 getenv = true
 
-queue 126
+queue 127

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     parser.add_option( '--visiblePS', dest = "visiblePS", action = "store_true",
                       help = "Unfold to visible phase space" )
     parser.add_option( "-u", "--unfolding_method", dest = "unfolding_method", default = 'TUnfold',
-                      help = "Unfolding method: RooUnfoldSvd (default), TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
+                      help = "Unfolding method:  TUnfold (default), RooUnfoldSvd, TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
 
     ( options, args ) = parser.parse_args()
     measurement_config = XSectionConfig( options.CoM )

--- a/src/cross_section_measurement/04_make_plots_matplotlib.py
+++ b/src/cross_section_measurement/04_make_plots_matplotlib.py
@@ -826,7 +826,7 @@ if __name__ == '__main__':
     parser.add_option( '--visiblePS', dest = "visiblePS", action = "store_true",
                       help = "Unfold to visible phase space" )
     parser.add_option( "-u", "--unfolding_method", dest = "unfolding_method", default = 'TUnfold',
-                      help = "Unfolding method: RooUnfoldSvd (default), TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
+                      help = "Unfolding method: TUnfold (default), RooUnfoldSvd, TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
 
     output_formats = ['png', 'pdf']
     ( options, args ) = parser.parse_args()

--- a/src/cross_section_measurement/05_make_tables.py
+++ b/src/cross_section_measurement/05_make_tables.py
@@ -639,7 +639,7 @@ if __name__ == '__main__':
     parser.add_option( '--visiblePS', dest = "visiblePS", action = "store_true",
                       help = "Unfold to visible phase space" )
     parser.add_option( "-u", "--unfolding_method", dest = "unfolding_method", default = 'TUnfold',
-                      help = "Unfolding method: RooUnfoldSvd (default), TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
+                      help = "Unfolding method: TUnfold (default), RooUnfoldSvd, TSVDUnfold, RooUnfoldTUnfold, RooUnfoldInvert, RooUnfoldBinByBin, RooUnfoldBayes" )
 
     (options, args) = parser.parse_args()
     measurement_config = XSectionConfig(options.CoM)

--- a/src/unfolding_tests/README.md
+++ b/src/unfolding_tests/README.md
@@ -1,35 +1,58 @@
 # Unfolding Tests
 
+## Get the best value for tau
+
+Make the configs.  These store where the input unfolding files and input data (ttbar normalisation) are.
+```shell
+python src/unfolding_tests/makeConfig.py 
+```
+You can get the best regularisation for one variable/phase space/channel (i.e. one config file), example:
+```shell
+python src/unfolding_tests/get_best_regularisation_TUnfold.py config/unfolding/VisiblePS/abs_lepton_eta_13TeV_combined_channel.json
+```
+or run on several using wildcards.  To run on all 13TeV variables, combined channel, in the visible phase:
+```shell
+python src/unfolding_tests/get_best_regularisation_TUnfold.py config/unfolding/VisiblePS/*_13TeV_combined_channel.json
+```
+
+
 ## Creating toy MC
 First we need to create a set of toy MC. Run
 ```shell
-python src/unfolding_tests/create_toy_mc.py -n 10
+python src/unfolding_tests/create_toy_mc.py -s powhegPythia
 ```
-For more information about available parameters, execute
+This will create 300 toy mc (300 is the default amount, probably need more for a full study) based on the powheg pythia sample.
+Other possible options for -s are currently "madgraph" and "amcatnlo"
+
+For more information about available parameters, do
 ```shell
 python src/unfolding_tests/create_toy_mc.py -h
 ```
-This will create a root file in data/toy_mc named toy_mc_MET_N_from_1_to_10_8TeV.root 
-(generally toy_mc_<variable>_N_from_1_to_<n>_<centre-of-mass>TeV.root).
+This will create a root file in data/toy_mc named toy_mc_powhegPythia_N_300_13TeV.root
+(generally toy_mc_<sample>_N_<n>_<centre-of-mass>TeV.root).
 This file can be used in the next step.
 
 ## Creating pull distributions
 ```shell
-python src/unfolding_tests/create_unfolding_pull_data.py -f data/toy_mc/toy_mc_MET_N_10_8TeV.root -c electron -n 10
+python src/unfolding_tests/create_unfolding_pull_data.py -f data/toy_mc/toy_mc_powhegPythia_N_300_13TeV.root -c combined -n 10 -v HT -s powhegPythia --tau 0.001
 ```
-which will create 
-```
-data/pull_data/8TeV/MET/10_input_toy_mc/10_input_toy_data/k_value_3/Pulls_multiple_data_multiple_unfolding_RooUnfoldSvd_electron_toy_MC_1_to_10_MC_1_to_10_data.txt
-```
-Again, please use
+This will consider the toy mc file, for HT in the combined channel.  It will take the first 10 toy mc in that file, and unfold with a tau value of 0.001.
+Output will be placed in:
 ```shell
-python src/unfolding_tests/create_unfolding_pull_data.py -h
+data/pull_data/13TeV/HT/powhegPythia/Pull_data_TUnfold_combined_0.001.txt
 ```
-for usage instructions. You can also use the DICE cluster for this step (all variables for a given centre-of-mass energy):
+The -s option is used for specifying the output directory (FIXME this could be derived from the input file)
+
+To run on dice, you can do :
 ```shell
-create_unfolding_pulls_on_DICE -c 8
+create_unfolding_pulls_on_DICE -c 13 -v MET,HT,ST,WPT,abs_lepton_eta,lepton_pt,NJets -s powhegPythia,madgraph,amcatnlo --scan_tau --doBestTau
 ```
-This script can only be executed on submission nodes (like soolin).
+
+This will submit a one job per tau value, for each variable (just in combined channel, as that's what we are typically interested in), and for each sample.
+Passing --scan_tau will tell the script to submit jobs for a range of tau values (from --tau_min, to --tau_max) equally spaced on a log scale (same number of jobs between 0.1-1, and 1-10 etc.).  The number of tau values to consider between each factor of 10 is set with --spacing.
+
+Passing --doBestTau will run one job for the best tau value, as specified in the main configuration file (config/cross_section_config.py)
+
 
 ## Analysing pull data
 Making the plots:
@@ -40,3 +63,8 @@ for more information on which plots are going to be produce please consult
 ```shell
 python src/unfolding_tests/make_unfolding_pull_plots.py -h
 ```
+
+
+python src/unfolding_tests/create_unfolding_pull_data.py -f data/toy_mc/toy_mc_madgraph_N_10_13TeV.root -c combined -n 10 -v MET -s test --tau 0.001
+
+create_unfolding_pulls_on_DICE -c 13 -v MET,HT,ST,WPT,abs_lepton_eta,lepton_pt,NJets -s powhegPythia,madgraph,amcatnlo --scan_tau --doBestTau

--- a/src/unfolding_tests/README.md
+++ b/src/unfolding_tests/README.md
@@ -3,6 +3,7 @@
 ## Get the best value for tau
 
 Make the configs.  These store where the input unfolding files and input data (ttbar normalisation) are.
+Check that you pick up the correct files - typically they are in your local dps directory, or on hdfs.
 ```shell
 python src/unfolding_tests/makeConfig.py 
 ```
@@ -15,6 +16,24 @@ or run on several using wildcards.  To run on all 13TeV variables, combined chan
 python src/unfolding_tests/get_best_regularisation_TUnfold.py config/unfolding/VisiblePS/*_13TeV_combined_channel.json
 ```
 
+## Closure test
+This will unfold a few pseudodata distributions with the central response matrix.
+E.g. Currently it unfolds the powheg pythia measured distribution with the powheg pythia response matrix, and compares the unfolded 'data' with the
+truth distribution.  It should give almost perfect agreement.
+It also unfolds a reweighted powheg pythia distribution and the madgraph distribution, and compares with the corresponding reweighted/madgraph truth.
+```shell
+python src/unfolding_tests/closure_test.py 
+```
+
+
+Making the plots (just pass a file created by the previous step):
+```shell
+python src/unfolding_tests/make_unfolding_pull_plots.py data/pull_data/13TeV/HT/powhegPythia/Pull_data_TUnfold_combined_0.001905.txt 
+```
+for more information on which plots are going to be produce please consult
+```shell
+python src/unfolding_tests/make_unfolding_pull_plots.py -h
+```
 
 ## Creating toy MC
 First we need to create a set of toy MC. Run
@@ -49,22 +68,18 @@ create_unfolding_pulls_on_DICE -c 13 -v MET,HT,ST,WPT,abs_lepton_eta,lepton_pt,N
 ```
 
 This will submit a one job per tau value, for each variable (just in combined channel, as that's what we are typically interested in), and for each sample.
-Passing --scan_tau will tell the script to submit jobs for a range of tau values (from --tau_min, to --tau_max) equally spaced on a log scale (same number of jobs between 0.1-1, and 1-10 etc.).  The number of tau values to consider between each factor of 10 is set with --spacing.
 
 Passing --doBestTau will run one job for the best tau value, as specified in the main configuration file (config/cross_section_config.py)
 
+Passing --scan_tau will tell the script to submit jobs for a range of tau values (from --tau_min, to --tau_max) equally spaced on a log scale (same number of jobs between 0.1-1, and 1-10 etc.).  The number of tau values to consider between each factor of 10 is set with --spacing.  Running with this option is not paritcularly useful at the moment.
+
 
 ## Analysing pull data
-Making the plots:
+Making the plots (just pass a file created by the previous step):
 ```shell
-python src/unfolding_tests/make_unfolding_pull_plots.py -s 8 -c electron data/pull_data/8TeV/MET/10_input_toy_mc/10_input_toy_data/k_value_3/*.txt
+python src/unfolding_tests/make_unfolding_pull_plots.py data/pull_data/13TeV/HT/powhegPythia/Pull_data_TUnfold_combined_0.001905.txt 
 ```
 for more information on which plots are going to be produce please consult
 ```shell
 python src/unfolding_tests/make_unfolding_pull_plots.py -h
 ```
-
-
-python src/unfolding_tests/create_unfolding_pull_data.py -f data/toy_mc/toy_mc_madgraph_N_10_13TeV.root -c combined -n 10 -v MET -s test --tau 0.001
-
-create_unfolding_pulls_on_DICE -c 13 -v MET,HT,ST,WPT,abs_lepton_eta,lepton_pt,NJets -s powhegPythia,madgraph,amcatnlo --scan_tau --doBestTau

--- a/src/unfolding_tests/closure_test.py
+++ b/src/unfolding_tests/closure_test.py
@@ -6,21 +6,40 @@ from rootpy.io import File
 
 from config.variable_binning import bin_edges_vis
 from tools.Unfolding import Unfolding, get_unfold_histogram_tuple
+from tools.hist_utilities import hist_to_value_error_tuplelist
 from config.cross_section_config import XSectionConfig
 from tools.plotting import compare_measurements, Histogram_properties
 from config import latex_labels
-
+from rootpy import asrootpy
+from collections import OrderedDict
 
 def main():
     config = XSectionConfig(13)
-#     method = 'RooUnfoldSvd'
-    method = 'RooUnfoldBayes'
-    file_for_unfolding = File(config.unfolding_central, 'read')
-    for channel in ['electron', 'muon', 'combined']:
-        for variable in config.variables:
-            tau_value = get_tau_value(config, channel, variable)
-            h_truth, h_measured, h_response, h_fakes = get_unfold_histogram_tuple(
-                inputfile=file_for_unfolding,
+    method = 'TUnfold'
+
+    file_for_response = File(config.unfolding_central, 'read')
+
+    file_for_powhegPythia  = File(config.unfolding_central, 'read')
+    file_for_madgraph = File(config.unfolding_madgraphMLM, 'read')
+    file_for_amcatnlo = File(config.unfolding_amcatnlo, 'read')
+
+    samples_and_files_to_compare = {
+    'powhegPythia' : file_for_powhegPythia,
+    'madgraph' : file_for_madgraph,
+    'amcatnlo' : file_for_amcatnlo
+    }
+
+    for channel in ['combined']:
+        # for variable in config.variables:
+        for variable in ['WPT']:
+
+
+            print ('Variable :',variable)
+
+            # Always unfold with the same response matrix and tau value
+            tau_value = get_tau_value(config, channel, variable) 
+            _, _, h_response, _ = get_unfold_histogram_tuple(
+                inputfile=file_for_response,
                 variable=variable,
                 channel=channel,
                 met_type=config.met_type,
@@ -28,14 +47,58 @@ def main():
                 ttbar_xsection=config.ttbar_xsection,
                 luminosity=config.luminosity,
                 load_fakes=False,
-                visiblePS=False,
+                visiblePS=True,
             )
-            unfolding = Unfolding(
-                h_truth, h_measured, h_response, h_fakes,
-                method=method, k_value=-1, tau=tau_value)
 
-            unfolded_data = unfolding.closureTest()
-            plot_closure(h_truth, unfolded_data, variable, channel,
+            # Dictionary to hold results
+            unfolded_and_truth_for_sample = {}
+
+            for sample, input_file_for_unfolding in samples_and_files_to_compare.iteritems():
+
+                _, _, h_response_to_unfold, _ = get_unfold_histogram_tuple(
+                    inputfile=input_file_for_unfolding,
+                    variable=variable,
+                    channel=channel,
+                    met_type=config.met_type,
+                    centre_of_mass=config.centre_of_mass_energy,
+                    ttbar_xsection=config.ttbar_xsection,
+                    luminosity=config.luminosity,
+                    load_fakes=False,
+                    visiblePS=True,
+                )
+
+                measured = asrootpy(h_response_to_unfold.ProjectionX('px',1))
+                truth = asrootpy(h_response_to_unfold.ProjectionY())
+
+                # Unfold, and set 'data' to 'measured' 
+                unfolding = Unfolding( measured,
+                    truth, measured, h_response, None,
+                    method=method, k_value=-1, tau=tau_value)
+                
+                unfolded_data = unfolding.unfold()
+
+                unfolded_and_truth_for_sample[sample] = {
+                                                            'truth' : truth.Clone(),
+                                                            'unfolded' : unfolded_data.Clone()
+                }
+
+                # print ('Measured :', list ( measured.y() ) )
+                # print ('Unfolded :', list ( unfolded_data.y() ) )
+                # print ('Truth :', list ( truth.y() ) )
+
+                # relDiff = ( unfolded_data - truth ) / truth * 100
+
+                # truth_tuple = hist_to_value_error_tuplelist(truth)
+                # unfolded_data_tuple = hist_to_value_error_tuplelist(unfolded_data)
+                # relDiff_tuple = hist_to_value_error_tuplelist(relDiff)
+
+                # for r in relDiff_tuple:
+                #     print (r[0],r[1])
+                # for u,t in zip( unfolded_data_tuple, truth_tuple ) :
+                #     print ( 'Unfolded :',u[0], u[1],'Truth :',t[0],t[1] )
+                #     # print ( ( u[0]/t[0] - 1) * 100, u[1], t[1])
+
+            plot_closure(unfolded_and_truth_for_sample, variable, channel,
                          config.centre_of_mass_energy, method)
 
 
@@ -48,7 +111,7 @@ def get_tau_value(config, channel, variable):
         return config.tau_values_combined[variable]
 
 
-def plot_closure(h_truth, unfolded_data, variable, channel, come, method):
+def plot_closure(unfolded_and_truths, variable, channel, come, method):
     hp = Histogram_properties()
     hp.name = '{channel}_closure_test_for_{variable}_at_{come}TeV'.format(
         channel=channel,
@@ -65,12 +128,31 @@ def plot_closure(h_truth, unfolded_data, variable, channel, come, method):
 
     output_folder = 'plots/unfolding/closure_test/{0}/'.format(method)
 
-    compare_measurements(models={'MC truth': h_truth},
-                         measurements={'unfolded reco': unfolded_data},
+    models = OrderedDict()
+    measurements = OrderedDict()
+    for sample in unfolded_and_truths:
+        models[sample + ' truth'] = unfolded_and_truths[sample]['truth']
+        measurements[sample + ' unfolded'] = unfolded_and_truths[sample]['unfolded']
+
+    # models['powhegPythia'] = unfolded_and_truths['powhegPythia']['truth']
+    # models['madgraph'] = unfolded_and_truths['madgraph']['truth']
+
+    # measurements['powhegPythia'] = unfolded_and_truths['powhegPythia']['unfolded']
+    # measurements['madgraph'] = unfolded_and_truths['madgraph']['unfolded']
+
+    print (models)
+    print (measurements)
+
+    compare_measurements(
+                         models = models,
+                         measurements = measurements,
+                         # models={'MC truth': h_truth},
+                         # measurements={'unfolded reco': unfolded_data},
                          show_measurement_errors=True,
                          histogram_properties=hp,
                          save_folder=output_folder,
-                         save_as=['png', 'pdf'])
+                         save_as=['pdf'],
+                         match_models_to_measurements = True)
 
 if __name__ == '__main__':
     main()

--- a/src/unfolding_tests/closure_test.py
+++ b/src/unfolding_tests/closure_test.py
@@ -4,37 +4,39 @@
 '''
 from rootpy.io import File
 
-from config.variable_binning import bin_edges_vis
+from config.variable_binning import bin_edges_vis, bin_widths_visiblePS
 from tools.Unfolding import Unfolding, get_unfold_histogram_tuple
-from tools.hist_utilities import hist_to_value_error_tuplelist
+from tools.hist_utilities import hist_to_value_error_tuplelist, value_error_tuplelist_to_hist
+from tools.Calculation import calculate_normalised_xsection
 from config.cross_section_config import XSectionConfig
 from tools.plotting import compare_measurements, Histogram_properties
 from config import latex_labels
 from rootpy import asrootpy
 from collections import OrderedDict
-
+from tools.latex import setup_matplotlib
+# latex, font, etc
+setup_matplotlib()
 def main():
     config = XSectionConfig(13)
     method = 'TUnfold'
 
     file_for_response = File(config.unfolding_central, 'read')
-
     file_for_powhegPythia  = File(config.unfolding_central, 'read')
-    file_for_madgraph = File(config.unfolding_madgraphMLM, 'read')
-    file_for_amcatnlo = File(config.unfolding_amcatnlo, 'read')
+    file_for_madgraph  = File(config.unfolding_madgraphMLM, 'read')
 
     samples_and_files_to_compare = {
-    'powhegPythia' : file_for_powhegPythia,
-    'madgraph' : file_for_madgraph,
-    'amcatnlo' : file_for_amcatnlo
+    'Central' : file_for_powhegPythia,
+    'Reweighted' : File('unfolding/13TeV/unfolding_TTJets_13TeV_asymmetric_withTopPtReweighting.root','read'),
+    'Madgraph' : file_for_madgraph,
+
     }
 
     for channel in ['combined']:
-        # for variable in config.variables:
-        for variable in ['WPT']:
+        for variable in config.variables:
+        # for variable in ['ST']:
 
 
-            print ('Variable :',variable)
+            print 'Variable :',variable
 
             # Always unfold with the same response matrix and tau value
             tau_value = get_tau_value(config, channel, variable) 
@@ -49,6 +51,8 @@ def main():
                 load_fakes=False,
                 visiblePS=True,
             )
+
+            integralOfResponse = asrootpy(h_response.ProjectionY()).integral(0,-1)
 
             # Dictionary to hold results
             unfolded_and_truth_for_sample = {}
@@ -70,6 +74,9 @@ def main():
                 measured = asrootpy(h_response_to_unfold.ProjectionX('px',1))
                 truth = asrootpy(h_response_to_unfold.ProjectionY())
 
+                scale = integralOfResponse / truth.integral(0,-1)
+                measured.Scale( scale )
+                truth.Scale( scale )
                 # Unfold, and set 'data' to 'measured' 
                 unfolding = Unfolding( measured,
                     truth, measured, h_response, None,
@@ -77,26 +84,13 @@ def main():
                 
                 unfolded_data = unfolding.unfold()
 
+                unfolded_xsection = calculate_xsection( unfolded_data, variable )
+                truth_xsection = calculate_xsection( truth, variable )
+
                 unfolded_and_truth_for_sample[sample] = {
-                                                            'truth' : truth.Clone(),
-                                                            'unfolded' : unfolded_data.Clone()
+                                                            'truth' : truth_xsection,
+                                                            'unfolded' : unfolded_xsection
                 }
-
-                # print ('Measured :', list ( measured.y() ) )
-                # print ('Unfolded :', list ( unfolded_data.y() ) )
-                # print ('Truth :', list ( truth.y() ) )
-
-                # relDiff = ( unfolded_data - truth ) / truth * 100
-
-                # truth_tuple = hist_to_value_error_tuplelist(truth)
-                # unfolded_data_tuple = hist_to_value_error_tuplelist(unfolded_data)
-                # relDiff_tuple = hist_to_value_error_tuplelist(relDiff)
-
-                # for r in relDiff_tuple:
-                #     print (r[0],r[1])
-                # for u,t in zip( unfolded_data_tuple, truth_tuple ) :
-                #     print ( 'Unfolded :',u[0], u[1],'Truth :',t[0],t[1] )
-                #     # print ( ( u[0]/t[0] - 1) * 100, u[1], t[1])
 
             plot_closure(unfolded_and_truth_for_sample, variable, channel,
                          config.centre_of_mass_energy, method)
@@ -120,10 +114,11 @@ def plot_closure(unfolded_and_truths, variable, channel, come, method):
     )
     v_latex = latex_labels.variables_latex[variable]
     unit = ''
-    if variable in ['HT', 'ST', 'MET', 'WPT']:
+    if variable in ['HT', 'ST', 'MET', 'WPT', 'lepton_pt']:
         unit = ' [GeV]'
     hp.x_axis_title = v_latex + unit
-    hp.y_axis_title = 'Events'
+    # plt.ylabel( r, CMS.y_axis_title )
+    hp.y_axis_title = r'$\frac{1}{\sigma}  \frac{d\sigma}{d' + v_latex + '}$' + unit
     hp.title = 'Closure tests for {variable}'.format(variable=v_latex)
 
     output_folder = 'plots/unfolding/closure_test/{0}/'.format(method)
@@ -134,25 +129,20 @@ def plot_closure(unfolded_and_truths, variable, channel, come, method):
         models[sample + ' truth'] = unfolded_and_truths[sample]['truth']
         measurements[sample + ' unfolded'] = unfolded_and_truths[sample]['unfolded']
 
-    # models['powhegPythia'] = unfolded_and_truths['powhegPythia']['truth']
-    # models['madgraph'] = unfolded_and_truths['madgraph']['truth']
-
-    # measurements['powhegPythia'] = unfolded_and_truths['powhegPythia']['unfolded']
-    # measurements['madgraph'] = unfolded_and_truths['madgraph']['unfolded']
-
-    print (models)
-    print (measurements)
 
     compare_measurements(
                          models = models,
                          measurements = measurements,
-                         # models={'MC truth': h_truth},
-                         # measurements={'unfolded reco': unfolded_data},
                          show_measurement_errors=True,
                          histogram_properties=hp,
                          save_folder=output_folder,
                          save_as=['pdf'],
                          match_models_to_measurements = True)
+
+def calculate_xsection( nEventsHistogram, variable ):
+    resultsAsTuple = hist_to_value_error_tuplelist( nEventsHistogram )
+    normalised_xsection = calculate_normalised_xsection( resultsAsTuple, bin_widths_visiblePS[variable], False )
+    return value_error_tuplelist_to_hist(normalised_xsection, bin_edges_vis[variable])
 
 if __name__ == '__main__':
     main()

--- a/src/unfolding_tests/create_toy_mc.py
+++ b/src/unfolding_tests/create_toy_mc.py
@@ -33,9 +33,7 @@ def main():
                       dest="output_folder", default='data/toy_mc/',
                       help="output folder for toy MC")
     parser.add_option("-s", dest="sample", default='madgraph',
-                        help='set underlying sample for creating the toy MC')
-    parser.add_option("-m", "--metType", dest="metType", default='type1',
-                      help="set MET type for analysis of MET, ST or MT")
+                        help='set underlying sample for creating the toy MC.  Possible options : madgraph, powhegPythia, amcatnlo.  Default is madgraph')
     parser.add_option("-c", "--centre-of-mass-energy", dest="CoM", default=13,
                       help="set the centre of mass energy for analysis. Default = 13 [TeV]", type=int)
     parser.add_option('-V', '--verbose', dest="verbose", action="store_true",
@@ -44,8 +42,6 @@ def main():
     (options, _) = parser.parse_args()
 
     measurement_config = XSectionConfig(options.CoM)
-#     variable = options.variable
-    met_type = measurement_config.translate_options[options.metType]
 
     input_file = None
     if options.sample == 'madgraph':
@@ -62,11 +58,11 @@ def main():
 #                   variable=variable,
                   n_toy=options.n_toy_mc,
                   centre_of_mass=options.CoM,
-                  ttbar_xsection=measurement_config.ttbar_xsection,
-                  met_type=met_type)
+                  ttbar_xsection=measurement_config.ttbar_xsection
+                  )
 
 
-def create_toy_mc(input_file, sample, output_folder, n_toy, centre_of_mass, ttbar_xsection, met_type):
+def create_toy_mc(input_file, sample, output_folder, n_toy, centre_of_mass, ttbar_xsection):
     from tools.file_utilities import make_folder_if_not_exists
     from tools.toy_mc import generate_toy_MC_from_distribution, generate_toy_MC_from_2Ddistribution
     from tools.Unfolding import get_unfold_histogram_tuple
@@ -83,9 +79,8 @@ def create_toy_mc(input_file, sample, output_folder, n_toy, centre_of_mass, ttba
                 h_truth, h_measured, h_response, _ = get_unfold_histogram_tuple(input_file_hists,
                                                                         variable,
                                                                         channel,
-                                                                        met_type,
-                                                                        centre_of_mass,
-                                                                        ttbar_xsection,
+                                                                        centre_of_mass = centre_of_mass,
+                                                                        ttbar_xsection = ttbar_xsection,
                                                                         visiblePS = True,
                                                                         load_fakes=False)
 

--- a/src/unfolding_tests/get_best_regularisation_TUnfold.py
+++ b/src/unfolding_tests/get_best_regularisation_TUnfold.py
@@ -41,6 +41,8 @@ from config import CMS
 from config.latex_labels import variables_latex
 from ROOT import TGraph, TSpline3, Double, TUnfoldDensity, TUnfold, TDecompSVD, TMatrixD, TCanvas, gROOT
 from numpy.linalg import svd
+from rootpy import asrootpy
+
 rc('font',**CMS.font)
 rc( 'text', usetex = True )
 
@@ -97,10 +99,10 @@ class RegularisationSettings(object):
                                               load_fakes = True,
                                               visiblePS = visiblePS
                                             )
-        self.h_truth = t
-        self.h_response = r
-        self.h_measured = m
-        self.h_fakes = f
+        self.h_truth = asrootpy ( t )
+        self.h_response = asrootpy ( r )
+        self.h_measured = asrootpy ( m )
+        self.h_fakes = asrootpy ( f )
         
         data_file = self.data['file']
         if data_file.endswith('.root'):
@@ -179,7 +181,7 @@ def tau_from_L_curve( unfoldingObject ):
     lCurve = TGraph()
     logTauX = TSpline3()
     logTauY = TSpline3()
-    iBest = unfoldingObject.ScanLcurve(100, 0., 0., lCurve, logTauX, logTauY);
+    iBest = unfoldingObject.ScanLcurve(500, 0., 0., lCurve, logTauX, logTauY);
 
     # Additional info, plots
     t = Double(0)
@@ -211,9 +213,9 @@ def tau_from_scan( unfoldingObject, regularisation_settings ):
 
     # Parameters of scan
     # Number of points to scan, and min/max tau
-    nScan = 100
-    minTau = 1.E-4
-    maxTau = 1.E-1
+    nScan = 1000
+    minTau = 1.E-6
+    maxTau = 1.E-0
 
     if variable == 'abs_lepton_eta':
         minTau = 1.E-8

--- a/src/unfolding_tests/makeConfig.py
+++ b/src/unfolding_tests/makeConfig.py
@@ -16,7 +16,7 @@ for channel in config.analysis_types.keys():
 
 		histogramTemplate = "%s_%s" % ( variable, channel )
 		outputJson = {
-		    "output_folder": "plots/unfolding_tests/bestRegularisation/FullPS", 
+		    "output_folder": "plots/unfolding/bestRegularisation/FullPS", 
 		    "output_format": ["png", "pdf"], 
 		    "centre-of-mass energy" : com,
 		    "channel": "%s" % channel,
@@ -48,7 +48,7 @@ for channel in config.analysis_types.keys():
 
 		histogramTemplate = "%s_%s" % ( variable, channel )
 		outputJson = {
-		    "output_folder": "plots/unfolding_tests/bestRegularisation/VisiblePS", 
+		    "output_folder": "plots/unfolding/bestRegularisation/VisiblePS", 
 		    "output_format": ["png", "pdf"], 
 		    "centre-of-mass energy" : com,
 		    "channel": "%s" % channel,

--- a/src/unfolding_tests/make_unfolding_pull_plots.py
+++ b/src/unfolding_tests/make_unfolding_pull_plots.py
@@ -96,7 +96,7 @@ def get_info_from_file_name(file_name):
 def main():
     parser = OptionParser(__doc__)
     parser.add_option("-o", "--output",
-                      dest="output_folder", default='plots/unfolding_pulls',
+                      dest="output_folder", default='plots/unfolding/pulls',
                       help="output folder for unfolding pull plots")
 
     (options, args) = parser.parse_args()

--- a/src/unfolding_tests/make_unfolding_pull_plots.py
+++ b/src/unfolding_tests/make_unfolding_pull_plots.py
@@ -108,11 +108,14 @@ def main():
         sys.exit(-1)
     file_name = args[0]
 
+    makeAllPlots(file_name, options.output_folder)
+
+def makeAllPlots(file_name, output_directory_base):
     centre_of_mass, channel, variable, sample, tau_value = get_info_from_file_name( file_name )
 
     k_value = 0
     output_folder = '{option_output}/{centre_of_mass}TeV/{variable}/{channel}/{sample}/'
-    output_folder = output_folder.format(option_output=options.output_folder,
+    output_folder = output_folder.format(option_output=output_directory_base,
                                          centre_of_mass=centre_of_mass,
                                          variable=variable,
                                          channel=channel,
@@ -190,7 +193,7 @@ def get_tau_value(tau_value, config, channel, variable):
 
 def get_value_title(k_value, tau_value):
     if tau_value >= 0:  # prefer tau
-        value = 'tau-value = {0}'.format(round(tau_value, 1))
+        value = 'tau-value = {0}'.format(round(tau_value, -1))
     else:
         value = 'k-value = {0}'.format(k_value)
     return value

--- a/tools/Calculation.py
+++ b/tools/Calculation.py
@@ -276,5 +276,3 @@ def calculate_stabilities( gen_vs_reco_histogram ):
         add_stability( s )
         
     return stabilities
-    
-

--- a/tools/Unfolding.py
+++ b/tools/Unfolding.py
@@ -5,6 +5,8 @@ Created on 31 Oct 2012
 '''
 from ROOT import gSystem, cout, TDecompSVD
 import config.RooUnfold as unfoldCfg
+from tools.ROOT_utils import set_root_defaults
+set_root_defaults( set_batch = True, msg_ignore_level = 3001 )
 from tools.hist_utilities import hist_to_value_error_tuplelist, fix_overflow
 gSystem.Load( unfoldCfg.library )
 from ROOT import RooUnfoldResponse, RooUnfoldParms, RooUnfold, RooUnfoldBayes, RooUnfoldSvd
@@ -66,8 +68,10 @@ class Unfolding:
                     if self.tau >= 0:
                         self.unfoldObject = RooUnfoldSvd( self.unfoldResponse, self.data, self.tau, self.n_toy )
             elif self.method == 'TUnfold':
-              self.unfoldObject = TUnfoldDensity( self.response, TUnfold.kHistMapOutputVert, TUnfold.kRegModeCurvature)
-              self.unfoldObject.SetInput( self.data )
+              self.unfoldObject = TUnfoldDensity( self.response, TUnfold.kHistMapOutputVert,
+                                                  TUnfold.kRegModeCurvature,
+                                                )
+              self.unfoldObject.SetInput( self.data, 1.0 )
               # self.unfoldObject.ScanLcurve( 30, 0, 0 )
 
     def unfold( self ):

--- a/tools/plotting.py
+++ b/tools/plotting.py
@@ -609,7 +609,8 @@ def compare_measurements( models = {}, measurements = {},
                             show_measurement_errors = True,
                             histogram_properties = Histogram_properties(),
                             save_folder = 'plots/',
-                            save_as = ['pdf', 'png'] ):
+                            save_as = ['pdf', 'png'],
+                            match_models_to_measurements = False ):
     """
         This function takes one or more models and compares it to a set of measurements.
         Models and measurements are supplied as dictionaries in the form of {'label': histogram}
@@ -632,12 +633,12 @@ def compare_measurements( models = {}, measurements = {},
     colorcycler = cycle( colors )
     
 #     markers = ['circle', 'triangledown', 'triangleup', 'diamond', 'square', 'star']
-    markers = [20, 23, 22, 33, 21, 29]
+    markers = [20, 21, 22, 33, 23, 29]
     markercycler = cycle( markers )
     # matplotlib
 #     lines = ["-", "--", "-.", ":"]
     # rootpy
-    lines = ["dashed", "solid", "dashdot", "dotted"]
+    lines = ["dashed"]
     linecycler = cycle( lines )
     
     for label, histogram in models.iteritems():
@@ -647,12 +648,18 @@ def compare_measurements( models = {}, measurements = {},
         histogram.color = next( colorcycler )
         histogram.linestyle = next( linecycler ) 
         rplt.hist( histogram, axex = axes, label = label )
-        
+    
+    if match_models_to_measurements:
+        colorcycler = cycle( colors )
+        markercycler = cycle( markers )
+        linecycler = cycle( lines )
+
     for label, histogram in measurements.iteritems():
-        histogram.markersize = 2 
+        histogram.markersize = 2
         histogram.markerstyle = next( markercycler )
         histogram.color = next( colorcycler )
         rplt.errorbar( histogram, axes = axes, label = label ,
+                        elinewidth = 2,
                        yerr = show_measurement_errors,
                        xerr = histogram_properties.xerr )
     


### PR DESCRIPTION
- Updated documentation
- Changes in scripts for running unfolding tests
- Additional response matrix after top pt reweighting
This is used as an additional sample for the unfolding closures.
- Change regularisation condition
Most important change.  Penalty term was aiming to suppress large deviations of the curvature of the unfolded data from zero.  Now it suppresses large deviations of the curvature from what is in the 'bias' distribution (i.e. the truth distribution from powheg pythia)