### PR TITLE
Run1 qcd btag plot

### DIFF
--- a/config/plots/Electron_abs_eta_8TeV_QCD_shape_comparison.json
+++ b/config/plots/Electron_abs_eta_8TeV_QCD_shape_comparison.json
@@ -1,0 +1,40 @@
+{
+    "command": "compare-hists", 
+    "files": [
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_8th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ],
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/Binned_MET_Analysis/patType1CorrectedPFMet_bin_0-27/electron_absolute_eta_0btag",
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/Binned_MET_Analysis/patType1CorrectedPFMet_bin_0-27/electron_absolute_eta_1btag",
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/Binned_MET_Analysis/patType1CorrectedPFMet_bin_0-27/electron_absolute_eta_2btags"
+    ],
+    "labels": [
+        "0 btag",
+        "1 btag",
+        "2 btags"
+    ], 
+    "output_folder": "plots/QCD_shape_e", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_QCD_btag_regions_in_electron_abs_eta_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.95, 1.05]
+    ], 
+    "title": [
+        "Comparison of electron $|\\eta|$ \\\\(QCD control regions: 0,1 and 2 btags) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$|\\eta(e)|$"
+    ], 
+    "x_limits": [
+        [0, 3]
+    ],
+    "y_axis_title": [
+        "normalised to unit area"
+    ],
+    "y_limits": [
+        [0, 0.2]
+    ],
+    "colours": ["green", "yellow", "red"],
+    "normalise": 1
+}

--- a/config/plots/MET_8TeV_electron_channel_QCD_shape_comparison.json
+++ b/config/plots/MET_8TeV_electron_channel_QCD_shape_comparison.json
@@ -1,0 +1,43 @@
+{
+    "command": "compare-hists", 
+    "files": [
+        "/hdfs/TopQuarkGroup/results/histogramfiles/AN-14-071_8th_draft/8TeV/central/SingleElectron_19584pb_PFElectron_PFMuon_PF2PATJets_PFMET.root"
+    ],
+    "histograms": [
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/MET/patType1CorrectedPFMet/MET_0btag",
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/MET/patType1CorrectedPFMet/MET_1btag",
+        "TTbar_plus_X_analysis/EPlusJets/QCD non iso e+jets/MET/patType1CorrectedPFMet/MET_2btags"
+    ],
+    "labels": [
+        "0 btag",
+        "1 btag",
+        "2 btags"
+    ], 
+    "output_folder": "plots/QCD_shape_e", 
+    "output_format": ["pdf"], 
+    "name_prefix": "compare_QCD_btag_regions_in_MET_electron_channel_",
+    "plot_type": "shape_comparison", 
+    "ratio_y_limits": [
+        [0.95, 1.05]
+    ], 
+    "title": [
+        "Comparison of $E_T^{\\text{miss}}$ \\\\(QCD control regions: 0,1 and 2 btags) $\\sqrt{s}$ = 8 TeV"
+    ], 
+    "x_axis_title": [
+         "$E_T^{\\text{miss}}$ [GeV]"
+    ], 
+    "x_limits": [
+        [0, 300]
+    ], 
+    "y_axis_title": [
+        "normalised to unit area"
+    ], 
+    "y_limits": [
+        [0, 0.6]
+    ],
+    "rebin" : [
+    	[0.0, 27.0, 52.0, 87.0, 130.0, 172.0, 300]	
+    ],
+    "colours": ["green", "yellow", "red"],
+    "normalise":1
+}

--- a/tools/HistSet.py
+++ b/tools/HistSet.py
@@ -59,6 +59,7 @@ class HistSet():
         if plot_options.has_key('colours'):
             colours = plot_options['colours']
 
+        normalise = False
         if plot_options.has_key( 'normalise' ):
             normalise = plot_options['normalise']
         


### PR DESCRIPTION
To answer the first referee comment, here is a comparison of electron |eta| for the first MET bin (high in QCD) and different b-tag multiplicities.

To reproduce execute in DPS:
```bash
plot config/plots/Electron_abs_eta_8TeV_QCD_shape_comparison.json config/plots/MET_8TeV_electron_channel_QCD_shape_comparison.json
```