### PR TITLE
Systematic Uncertainty Update

### DIFF
--- a/config/cross_section_config.py
+++ b/config/cross_section_config.py
@@ -191,8 +191,8 @@ class XSectionConfig():
             'JER_down':'_JERDown',
             'JER_up':'_JERUp',
 
-
-            'PileUpSystematic' : '',
+            'PileUp_up' : '',
+            'PileUp_down' : '',
 
             # Other MET uncertainties not already included
             'ElectronEnUp' : '',
@@ -203,14 +203,6 @@ class XSectionConfig():
             'TauEnDown' : '',
             'UnclusteredEnUp' : '',
             'UnclusteredEnDown' : '',
-            # 'ElectronEn_up' : 'ElectronEnUp',
-            # 'ElectronEn_down' : 'ElectronEnDown',
-            # 'MuonEn_up' : 'MuonEnUp',
-            # 'MuonEn_down' : 'MuonEnDown',
-            # 'TauEn_up' : 'TauEnUp',
-            # 'TauEn_down' : 'TauEnDown',
-            # 'UnclusteredEn_up' : 'UnclusteredEnUp',
-            # 'UnclusteredEn_down' : 'UnclusteredEnDown',
         }
 
         self.list_of_systematics = {
@@ -233,7 +225,7 @@ class XSectionConfig():
                                             'TTJets_combinedup', 'TTJets_combineddown'],
 
             # Event Reweighting
-            'PileUp'                    : ['PileUpSystematic', 'PileUpSystematic'],
+            'PileUp'                    : ['PileUp_up', 'PileUp_down'],
             'JES'                       : ['JES_up', 'JES_down'],
             'JER'                       : ['JER_up', 'JER_down'],
             'BJet'                      : ['BJet_up', 'BJet_down'],
@@ -279,7 +271,7 @@ class XSectionConfig():
             'factorisationup', 'factorisationdown', 
             'renormalisationup', 'renormalisationdown', 
             'combinedup', 'combineddown', 
-            'alphaSup', 'alphaSdown'
+            'alphaSup', 'alphaSdown',
         ]
 
         self.generator_mcsamples = [

--- a/config/cross_section_config.py
+++ b/config/cross_section_config.py
@@ -226,6 +226,12 @@ class XSectionConfig():
             'TTJets_mass'               : ['TTJets_massup', 'TTJets_massdown'],
             'TTJets_hadronisation'      : ['TTJets_hadronisation', 'TTJets_hadronisation'],
             'TTJets_NLOgenerator'       : ['TTJets_NLOgenerator', 'TTJets_NLOgenerator'],
+
+            'TTJets_alphaS'             : ['TTJets_alphaSup', 'TTJets_alphaSdown'],
+            'TTJets_envelope'           : ['TTJets_factorisationup', 'TTJets_factorisationdown',
+                                            'TTJets_renormalisationup', 'TTJets_renormalisationdown',
+                                            'TTJets_combinedup', 'TTJets_combineddown'],
+
             # Event Reweighting
             'PileUp'                    : ['PileUpSystematic', 'PileUpSystematic'],
             'JES'                       : ['JES_up', 'JES_down'],
@@ -269,7 +275,11 @@ class XSectionConfig():
             'scaleup', 'scaledown',
             'massup', 'massdown',
             'hadronisation',
-            'NLOgenerator'
+            'NLOgenerator',
+            'factorisationup', 'factorisationdown', 
+            'renormalisationup', 'renormalisationdown', 
+            'combinedup', 'combineddown', 
+            'alphaSup', 'alphaSdown'
         ]
 
         self.generator_mcsamples = [
@@ -415,6 +425,14 @@ class XSectionConfig():
         self.unfolding_matching_down = self.unfolding_matching_down_raw.replace( '.root', '_asymmetric.root' )
         self.unfolding_matching_up = self.unfolding_matching_up_raw.replace( '.root', '_asymmetric.root' )
 
+        self.unfolding_renormalisation_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_05muR1muF.root' % self.centre_of_mass_energy
+        self.unfolding_renormalisation_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_2muR1muF.root' % self.centre_of_mass_energy
+        self.unfolding_factorisation_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_1muR05muF.root' % self.centre_of_mass_energy
+        self.unfolding_factorisation_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_1muR2muF.root' % self.centre_of_mass_energy
+        self.unfolding_combined_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_05muR05muF.root' % self.centre_of_mass_energy
+        self.unfolding_combined_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_2muR2muF.root' % self.centre_of_mass_energy
+        self.unfolding_alphaS_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_alphaSDown.root' % self.centre_of_mass_energy
+        self.unfolding_alphaS_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_asymmetric_alphaSUp.root' % self.centre_of_mass_energy
 
         self.unfolding_mass_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massdown_asymmetric.root' % self.centre_of_mass_energy
         self.unfolding_mass_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massup_asymmetric.root' % self.centre_of_mass_energy

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -92,13 +92,9 @@ if __name__ == '__main__':
     all_systematics = append_PDF_uncertainties(all_systematics)
 
     list_of_systematics = all_systematics
-    # If you want different listsof systematics can just do some manipulation here
+    # If you want different lists of systematics can just do some manipulation here
 
-    # Print the systematics if required
-    print_dictionary("List of the systematics in use", list_of_systematics)
-
-    # for channel in ['electron', 'muon', 'combined', 'combinedBeforeUnfolding']:
-    for channel in ['muon']:
+    for channel in ['electron', 'muon', 'combined', 'combinedBeforeUnfolding']:
         print("Channel in use is {0} : ".format(channel))
 
         # Output folder of covariance matrices
@@ -116,26 +112,27 @@ if __name__ == '__main__':
 
         # Retreive the normalised cross sections, for all groups in list_of_systematics.
         systematic_normalised_uncertainty, unfolded_systematic_normalised_uncertainty = get_normalised_cross_sections(opts, list_of_systematics)
-        print_dictionary("Normalised cross sections of the systematics in use", systematic_normalised_uncertainty)
+        # print_dictionary("Normalised cross sections of the systematics in use", systematic_normalised_uncertainty)
         # print_dictionary("Unfolded normalised cross sections of the systematics in use", unfolded_systematic_normalised_uncertainty)
 
-        # # Get and symmetrise the uncertainties
-        # x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(systematic_normalised_uncertainty, opts)
-        # unfolded_x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(unfolded_systematic_normalised_uncertainty, opts)
-        # # print_dictionary("Normalised cross sections of the systematics with symmetrised uncertainties", x_sec_with_symmetrised_systematics)
-        # # print_dictionary("Unfolded normalised cross sections of the systematics  with symmetrised uncertainties", unfolded_x_sec_with_symmetrised_systematics)
+        # Get and symmetrise the uncertainties
+        x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(systematic_normalised_uncertainty, opts)
+        unfolded_x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(unfolded_systematic_normalised_uncertainty, opts)
+        # print_dictionary("Normalised cross sections of the systematics with symmetrised uncertainties", x_sec_with_symmetrised_systematics)
+        # print_dictionary("Unfolded normalised cross sections of the systematics  with symmetrised uncertainties", unfolded_x_sec_with_symmetrised_systematics)
 
-        # # Create covariance matrices
-        # generate_covariance_matrices(opts, x_sec_with_symmetrised_systematics)
-        # generate_covariance_matrices(opts, unfolded_x_sec_with_symmetrised_systematics)
+        # Create covariance matrices
+        generate_covariance_matrices(opts, x_sec_with_symmetrised_systematics)
+        generate_covariance_matrices(opts, unfolded_x_sec_with_symmetrised_systematics)
 
-        # # Combine all systematic uncertainties for each of the groups of systematics
-        # full_measurement = get_measurement_with_total_systematic_uncertainty(opts, x_sec_with_symmetrised_systematics)
-        # full_unfolded_measurement = get_measurement_with_total_systematic_uncertainty(opts, unfolded_x_sec_with_symmetrised_systematics)
-        # # print_dictionary("Measurement with total systematic error for each systematic group", full_measurement)
-        # # print_dictionary("Unfolded measurement with total systematic error for each systematic group", full_unfolded_measurement)
+        # Combine all systematic uncertainties for each of the groups of systematics
+        # Currently returns (Value, SysUp, SysDown) - Need to include stat?
+        full_measurement = get_measurement_with_total_systematic_uncertainty(opts, x_sec_with_symmetrised_systematics)
+        full_unfolded_measurement = get_measurement_with_total_systematic_uncertainty(opts, unfolded_x_sec_with_symmetrised_systematics)
+        # print_dictionary("Measurement with total systematic error for each systematic group", full_measurement)
+        # print_dictionary("Unfolded measurement with total systematic error for each systematic group", full_unfolded_measurement)
 
-        # # Write central +- error to JSON. Group of systematics in question is included in outputfile name.
-        # for keys in list_of_systematics.keys():
-        #     write_normalised_xsection_measurement(opts, full_measurement[keys], full_unfolded_measurement[keys], summary = keys )
+        # Write central +- error to JSON. Group of systematics in question is included in outputfile name.
+        # Summary if you want to specify specific list. e.g. GeneratorOnly etc
+        write_normalised_xsection_measurement(opts, full_measurement, full_unfolded_measurement, summary = '' )
 

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -97,7 +97,8 @@ if __name__ == '__main__':
     # Print the systematics if required
     print_dictionary("List of the systematics in use", list_of_systematics)
 
-    for channel in ['electron', 'muon', 'combined', 'combinedBeforeUnfolding']:
+    # for channel in ['electron', 'muon', 'combined', 'combinedBeforeUnfolding']:
+    for channel in ['muon']:
         print("Channel in use is {0} : ".format(channel))
 
         # Output folder of covariance matrices
@@ -115,7 +116,7 @@ if __name__ == '__main__':
 
         # Retreive the normalised cross sections, for all groups in list_of_systematics.
         systematic_normalised_uncertainty, unfolded_systematic_normalised_uncertainty = get_normalised_cross_sections(opts, list_of_systematics)
-        # print_dictionary("Normalised cross sections of the systematics in use", systematic_normalised_uncertainty)
+        print_dictionary("Normalised cross sections of the systematics in use", systematic_normalised_uncertainty)
         # print_dictionary("Unfolded normalised cross sections of the systematics in use", unfolded_systematic_normalised_uncertainty)
 
         # # Get and symmetrise the uncertainties

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -91,11 +91,8 @@ if __name__ == '__main__':
     # Add in the PDF weights
     all_systematics = append_PDF_uncertainties(all_systematics)
 
-    list_of_systematics = {}
-    # Do you want to use different groups of systematics?
-    list_of_systematics['all'] = all_systematics
-    # Get separated lists of systematics e.g. only hadronisation etc...
-    # TODO
+    list_of_systematics = all_systematics
+    # If you want different listsof systematics can just do some manipulation here
 
     # Print the systematics if required
     print_dictionary("List of the systematics in use", list_of_systematics)

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -118,23 +118,23 @@ if __name__ == '__main__':
         # print_dictionary("Normalised cross sections of the systematics in use", systematic_normalised_uncertainty)
         # print_dictionary("Unfolded normalised cross sections of the systematics in use", unfolded_systematic_normalised_uncertainty)
 
-        # Get and symmetrise the uncertainties
-        x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(systematic_normalised_uncertainty, opts)
-        unfolded_x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(unfolded_systematic_normalised_uncertainty, opts)
-        # print_dictionary("Normalised cross sections of the systematics with symmetrised uncertainties", x_sec_with_symmetrised_systematics)
-        # print_dictionary("Unfolded normalised cross sections of the systematics  with symmetrised uncertainties", unfolded_x_sec_with_symmetrised_systematics)
+        # # Get and symmetrise the uncertainties
+        # x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(systematic_normalised_uncertainty, opts)
+        # unfolded_x_sec_with_symmetrised_systematics = get_symmetrised_systematic_uncertainty(unfolded_systematic_normalised_uncertainty, opts)
+        # # print_dictionary("Normalised cross sections of the systematics with symmetrised uncertainties", x_sec_with_symmetrised_systematics)
+        # # print_dictionary("Unfolded normalised cross sections of the systematics  with symmetrised uncertainties", unfolded_x_sec_with_symmetrised_systematics)
 
-        # Create covariance matrices
-        generate_covariance_matrices(opts, x_sec_with_symmetrised_systematics)
-        generate_covariance_matrices(opts, unfolded_x_sec_with_symmetrised_systematics)
+        # # Create covariance matrices
+        # generate_covariance_matrices(opts, x_sec_with_symmetrised_systematics)
+        # generate_covariance_matrices(opts, unfolded_x_sec_with_symmetrised_systematics)
 
-        # Combine all systematic uncertainties for each of the groups of systematics
-        full_measurement = get_measurement_with_total_systematic_uncertainty(opts, x_sec_with_symmetrised_systematics)
-        full_unfolded_measurement = get_measurement_with_total_systematic_uncertainty(opts, unfolded_x_sec_with_symmetrised_systematics)
-        # print_dictionary("Measurement with total systematic error for each systematic group", full_measurement)
-        # print_dictionary("Unfolded measurement with total systematic error for each systematic group", full_unfolded_measurement)
+        # # Combine all systematic uncertainties for each of the groups of systematics
+        # full_measurement = get_measurement_with_total_systematic_uncertainty(opts, x_sec_with_symmetrised_systematics)
+        # full_unfolded_measurement = get_measurement_with_total_systematic_uncertainty(opts, unfolded_x_sec_with_symmetrised_systematics)
+        # # print_dictionary("Measurement with total systematic error for each systematic group", full_measurement)
+        # # print_dictionary("Unfolded measurement with total systematic error for each systematic group", full_unfolded_measurement)
 
-        # Write central +- error to JSON. Group of systematics in question is included in outputfile name.
-        for keys in list_of_systematics.keys():
-            write_normalised_xsection_measurement(opts, full_measurement[keys], full_unfolded_measurement[keys], summary = keys )
+        # # Write central +- error to JSON. Group of systematics in question is included in outputfile name.
+        # for keys in list_of_systematics.keys():
+        #     write_normalised_xsection_measurement(opts, full_measurement[keys], full_unfolded_measurement[keys], summary = keys )
 

--- a/src/cross_section_measurement/03_calculate_systematics.py
+++ b/src/cross_section_measurement/03_calculate_systematics.py
@@ -95,6 +95,7 @@ if __name__ == '__main__':
     # If you want different lists of systematics can just do some manipulation here
 
     for channel in ['electron', 'muon', 'combined', 'combinedBeforeUnfolding']:
+    # for channel in ['muon']:
         print("Channel in use is {0} : ".format(channel))
 
         # Output folder of covariance matrices

--- a/src/cross_section_measurement/create_measurement.py
+++ b/src/cross_section_measurement/create_measurement.py
@@ -40,8 +40,7 @@ def main():
     categories = ['QCD_shape']
     categories.extend(measurement_config.categories_and_prefixes.keys())
     categories.extend(measurement_config.rate_changing_systematics_names)
-    categories.extend([measurement_config.vjets_theory_systematic_prefix +
-                       systematic for systematic in measurement_config.generator_systematics if not ('mass' in systematic or 'hadronisation' in systematic or 'NLO' in systematic)])
+    categories.extend([measurement_config.vjets_theory_systematic_prefix + scale for scale in ['scaleup', 'scaledown']])
 
     for variable in measurement_config.variables:
         for category in categories:
@@ -74,7 +73,6 @@ def create_measurement(com, category, variable, channel, phase_space, norm_metho
         return
 
     m = None
-
     if category == 'central':
         m = tools.measurement.Measurement(category)
     else:
@@ -448,12 +446,24 @@ def create_input(config, sample, variable, category, channel, template,
         weight_branches.append('1')
     else:
         weight_branches.append('EventWeight')
-        if category != 'PileUpSystematic':
+
+        if 'PileUp' not in category:
             weight_branches.append('PUWeight')
+        elif category == 'PileUp_up':
+            weight_branches.append('PUWeight_up')
+        elif category == 'PileUp_down':
+            weight_branches.append('PUWeight_down')
+        else:
+            weight_branches.append('1')
+
         if category == 'BJet_down':
             weight_branches.append('BJetDownWeight')
         elif category == 'BJet_up':
             weight_branches.append('BJetUpWeight')
+        elif category == 'LightJet_down':
+            weight_branches.append('LightJetDownWeight')
+        elif category == 'LightJet_up':
+            weight_branches.append('LightJetUpWeight')
         else:
             weight_branches.append('BJetWeight')
 

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -17,7 +17,7 @@ def write_normalised_xsection_measurement(options, measurement, measurement_unfo
     method=options['method']
     channel=options['channel']
 
-    output_file = '{path_to_JSON}/TEST/central/normalised_xsection_{channel}_{method}_with_errors.txt'
+    output_file = '{path_to_JSON}/central/normalised_xsection_{channel}_{method}_with_errors.txt'
     output_file = output_file.format(
                     path_to_JSON = path_to_JSON,
                     channel = channel,

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -217,6 +217,7 @@ def calculate_total_PDFuncertainty(options, central_measurement, pdf_uncertainty
     @param pdf_uncertainty_values: dictionary of measurements with different PDF weights; 
                                     format {PDFWeights_%d: measurement}
     '''
+
     number_of_bins = options['number_of_bins']
     pdf_min = []
     pdf_max = []
@@ -235,9 +236,14 @@ def calculate_total_PDFuncertainty(options, central_measurement, pdf_uncertainty
                 negative.append(pdf_uncertainty)
             else:
                 positive.append(pdf_uncertainty)
-                
-        pdf_max.append(sqrt(sum(max(x - central, y - central, 0) ** 2 for x, y in zip(negative, positive))))
-        pdf_min.append(sqrt(sum(max(central - x, central - y, 0) ** 2 for x, y in zip(negative, positive))))
+
+        # now to calculate the RMS (sigma)
+        rms_up, rms_down = 0, 0
+        for n,p in zip(negative, positive):
+            rms_up += (p-central)**2
+            rms_down += (n-central)**2   
+        pdf_max.append( sqrt( rms_up / (len(positive)-1) ))
+        pdf_min.append( sqrt( rms_down / (len(negative)-1) ))
 
     return pdf_min, pdf_max  
 

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -127,32 +127,33 @@ def get_normalised_cross_sections(options, list_of_systematics):
     unfolded_normalised_systematic_uncertainty_x_sections = deepcopy(list_of_systematics)
 
     central_measurement, central_measurement_unfolded = read_normalised_xsection_measurement(options, 'central')
-    for group_of_systematics, systematics_in_list in list_of_systematics.iteritems():
-        for systematic, variation in systematics_in_list.iteritems():
-            normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic] = [central_measurement]
-            unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic] = [central_measurement]
-            if (systematic == 'PDF'):
-                syst_unc_x_sec, unf_syst_unc_x_sec = read_normalised_xsection_systematics(options, variation, isPDF=True)
 
-                # Get full PDF combination
-                pdf_total_lower, pdf_total_upper = calculate_total_PDFuncertainty(options, central_measurement, syst_unc_x_sec)
-                unf_pdf_total_lower, unf_pdf_total_upper = calculate_total_PDFuncertainty(options, central_measurement_unfolded, unf_syst_unc_x_sec)
+    for systematic, variation in list_of_systematics.iteritems():
+        # central measurement
+        normalised_systematic_uncertainty_x_sections[systematic] = [central_measurement]
+        unfolded_normalised_systematic_uncertainty_x_sections[systematic] = [central_measurement]
+        if (systematic == 'PDF'):
+            syst_unc_x_sec, unf_syst_unc_x_sec = read_normalised_xsection_systematics(options, variation, isPDF=True)
 
-                for PDF_Weight in variation:
-                    normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(syst_unc_x_sec[PDF_Weight])
-                    unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(unf_syst_unc_x_sec[PDF_Weight])
-                normalised_systematic_uncertainty_x_sections[group_of_systematics]['PDF_Combined'] = \
-                    [central_measurement, pdf_total_upper, pdf_total_lower]
-                unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics]['PDF_Combined'] = \
-                    [central_measurement_unfolded, unf_pdf_total_upper, unf_pdf_total_lower]
-                del normalised_systematic_uncertainty_x_sections[group_of_systematics]['PDF']
-                del unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics]['PDF']
-            else:
-                syst_unc_x_sec, unf_syst_unc_x_sec = read_normalised_xsection_systematics(options, variation)
-                normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(syst_unc_x_sec['upper'])
-                normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(syst_unc_x_sec['lower'])
-                unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(unf_syst_unc_x_sec['upper'])
-                unfolded_normalised_systematic_uncertainty_x_sections[group_of_systematics][systematic].append(unf_syst_unc_x_sec['lower'])
+            # Get full PDF combination
+            pdf_total_lower, pdf_total_upper = calculate_total_PDFuncertainty(options, central_measurement, syst_unc_x_sec)
+            unf_pdf_total_lower, unf_pdf_total_upper = calculate_total_PDFuncertainty(options, central_measurement_unfolded, unf_syst_unc_x_sec)
+
+            for PDF_Weight in variation:
+                normalised_systematic_uncertainty_x_sections[systematic].append(syst_unc_x_sec[PDF_Weight])
+                unfolded_normalised_systematic_uncertainty_x_sections[systematic].append(unf_syst_unc_x_sec[PDF_Weight])
+            normalised_systematic_uncertainty_x_sections['PDF_Combined'] = \
+                [central_measurement, pdf_total_upper, pdf_total_lower]
+            unfolded_normalised_systematic_uncertainty_x_sections['PDF_Combined'] = \
+                [central_measurement_unfolded, unf_pdf_total_upper, unf_pdf_total_lower]
+            del normalised_systematic_uncertainty_x_sections['PDF']
+            del unfolded_normalised_systematic_uncertainty_x_sections['PDF']
+        else:
+            syst_unc_x_sec, unf_syst_unc_x_sec = read_normalised_xsection_systematics(options, variation)
+            normalised_systematic_uncertainty_x_sections[systematic].append(syst_unc_x_sec['upper'])
+            normalised_systematic_uncertainty_x_sections[systematic].append(syst_unc_x_sec['lower'])
+            unfolded_normalised_systematic_uncertainty_x_sections[systematic].append(unf_syst_unc_x_sec['upper'])
+            unfolded_normalised_systematic_uncertainty_x_sections[systematic].append(unf_syst_unc_x_sec['lower'])
 
     return normalised_systematic_uncertainty_x_sections, unfolded_normalised_systematic_uncertainty_x_sections
 
@@ -196,17 +197,22 @@ def get_symmetrised_systematic_uncertainty(norm_syst_unc_x_secs, options):
         [signed uncertainty]        = [sign, sign...sign] For N Bins
     '''
     normalised_x_sections_with_symmetrised_systematics = deepcopy(norm_syst_unc_x_secs)
-    for group_of_systematics, systematics_in_list in norm_syst_unc_x_secs.iteritems():
-        for systematic, variation in systematics_in_list.iteritems():
+        for systematic, variation in norm_syst_unc_x_secs.iteritems():
             central_measurement = variation[0]
             upper_measurement = variation[1]
             lower_measurement = variation[2]
 
             isTopMassSystematic = True if systematic == 'TTJets_mass' else False
 
-            symmetrised_uncertainties, signed_uncertainties = get_symmetrised_errors(central_measurement, upper_measurement, lower_measurement, options, isTopMassSystematic )
+            symmetrised_uncertainties, signed_uncertainties = get_symmetrised_errors(
+                central_measurement, 
+                upper_measurement, 
+                lower_measurement, 
+                options, 
+                isTopMassSystematic 
+            )
 
-            normalised_x_sections_with_symmetrised_systematics[group_of_systematics][systematic] = \
+            normalised_x_sections_with_symmetrised_systematics[systematic] = \
                 [central_measurement, symmetrised_uncertainties, signed_uncertainties] 
     return normalised_x_sections_with_symmetrised_systematics           
 

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -383,9 +383,9 @@ def scaleTopMassSystematic( upper_uncertainty, lower_uncertainty, topMasses, top
 
     return upper_uncertainty, lower_uncertainty
 
+@deprecated
 def get_sign(central, upper, lower, upper_variation, lower_variation):
     '''
-    @deprecated
     Currently Obsolete.
     Returns the sign of the uncertainty - i.e. was the upper variation bigger than the lower variation
     Returns 0 if the systematic is symmetrical

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -186,11 +186,14 @@ def get_normalised_cross_sections(options, list_of_systematics):
     return normalised_systematic_uncertainty_x_sections, unfolded_normalised_systematic_uncertainty_x_sections
 
 
-def get_scale_envelope(options, d_syst):
+def get_scale_envelope(options, d_scale_syst):
     '''
     Calculate the scale envelope for the renormalisation/factorisation/combined systematic uncertainties
     For all up variations in a bin keep the highest
     For all down variations in a bin keep the lowest
+
+    d_scale_syst is a dictionary containing all the Q2 scale variations
+    Retrieve the 3 up(down) variations from d_scale_syst and choose max(min) value as the envelope for each bin
     '''
     down_variations = []
     up_variations = []
@@ -198,11 +201,11 @@ def get_scale_envelope(options, d_syst):
     envelope_down = []
 
     # Separate into up/down scale variations
-    for scale_variation in d_syst:
+    for scale_variation in d_scale_syst:
         if 'down' in scale_variation:
-            down_variations.append(d_syst[scale_variation])
+            down_variations.append(d_scale_syst[scale_variation])
         elif 'up' in scale_variation:
-            up_variations.append(d_syst[scale_variation])
+            up_variations.append(d_scale_syst[scale_variation])
 
     # find min/max
     for v1, v2, v3 in zip (up_variations[0], up_variations[1], up_variations[2]):
@@ -382,6 +385,7 @@ def scaleTopMassSystematic( upper_uncertainty, lower_uncertainty, topMasses, top
 
 def get_sign(central, upper, lower, upper_variation, lower_variation):
     '''
+    @deprecated
     Currently Obsolete.
     Returns the sign of the uncertainty - i.e. was the upper variation bigger than the lower variation
     Returns 0 if the systematic is symmetrical

--- a/tools/systematic.py
+++ b/tools/systematic.py
@@ -309,6 +309,12 @@ def get_symmetrised_systematic_uncertainty(norm_syst_unc_x_secs, options):
                 signed_uncertainties,
             ]         
 
+    # Combine LightJet and BJet Systematics
+    bJet = normalised_x_sections_with_symmetrised_systematics['BJet'][0]
+    lightJet = normalised_x_sections_with_symmetrised_systematics['LightJet'][0]
+    bJet_tot = [combine_errors_in_quadrature([e1, e2]) for e1, e2 in zip(bJet, lightJet)]
+    normalised_x_sections_with_symmetrised_systematics['BJet'][0] = bJet_tot
+
     # Combine PDF with alphaS variations
     alphaS = normalised_x_sections_with_symmetrised_systematics['TTJets_alphaS'][0]
     pdf = normalised_x_sections_with_symmetrised_systematics['PDF'][0]
@@ -316,8 +322,10 @@ def get_symmetrised_systematic_uncertainty(norm_syst_unc_x_secs, options):
     normalised_x_sections_with_symmetrised_systematics['PDF'][0] = pdf_tot
     # TODO combine the signs....
 
-    # Now alphaS is combined with pdfs dont need it in dictionary anymore.
+    # Now alphaS is combined with pdfs dont need it in dictionary anymore. nor LightJet
+    del normalised_x_sections_with_symmetrised_systematics['LightJet']
     del normalised_x_sections_with_symmetrised_systematics['TTJets_alphaS']
+
     return normalised_x_sections_with_symmetrised_systematics           
 
 


### PR DESCRIPTION
Remove the options for separate lists of systematics simultaneously. Can just create them and run one after the other anyway...
add the renormalisation and factorisation scale variations in
Create an envelope of the scale variations
Make PDF uncertainty from the RMS of the variations.
Realised that we were getting the symmetrised uncertainty by finding the max difference between the central value and the pdf uncertainty, not the central value and upper PDF variation... Rearranged so that PDF uncertainty is now calculated in the correct place.
Correctly find PU variation files
Correctly find LightJet variation files
Combine BJet and Light Jet syst uncertainties