### PR TITLE
Covariance matrices

### DIFF
--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -285,8 +285,8 @@ class XSectionConfig():
             'BJet'                      : ['BJet_up', 'BJet_down'],
             'LightJet'                  : ['LightJet_up', 'LightJet_down'],
             # Lepton Uncertainties (Id/Iso/Trig Eff)
-            'Electron'                  : ['Electron_up', 'Electron_down'],
-            'Muon'                      : ['Muon_up', 'Muon_down'],
+            # 'Electron'                  : ['Electron_up', 'Electron_down'],
+            # 'Muon'                      : ['Muon_up', 'Muon_down'],
             # PDF Uncertainties
             'PDF'                       : ['PDF', 'PDF'],
             # MET Uncertainties

--- a/dps/utils/systematic.py
+++ b/dps/utils/systematic.py
@@ -278,17 +278,21 @@ def calculate_total_PDFuncertainty(options, central_measurement, pdf_uncertainty
     '''
     number_of_bins = options['number_of_bins']
     pdf_sym = []
+    pdf_sign = []
 
     for bin_i in xrange(number_of_bins):
         central = central_measurement[bin_i][0]
 
         # now to calculate the RMS (sigma) for all PDF variations
         rms = 0
+        mean = 0
         for pdf_variation in pdf_uncertainty_values:
             variation = pdf_variation[1][bin_i]
             rms += (variation-central)**2
+            mean += (variation-central)
         pdf_sym.append( sqrt( rms / (len(pdf_uncertainty_values)-1) ))
-    return pdf_sym  
+        pdf_sign.append( np.sign( mean / len(pdf_uncertainty_values) ) )
+    return pdf_sym, pdf_sign
 
 
 def get_symmetrised_systematic_uncertainty(options, norm_syst_unc_x_secs ):
@@ -311,7 +315,7 @@ def get_symmetrised_systematic_uncertainty(options, norm_syst_unc_x_secs ):
     for systematic, variation in norm_syst_unc_x_secs.iteritems():
         if (systematic == 'PDF'):
             # Replace all PDF weights with full PDF combination
-            pdf_sym = calculate_total_PDFuncertainty(
+            pdf_sym, pdf_sign = calculate_total_PDFuncertainty(
                 options, 
                 central_measurement, 
                 variation,
@@ -319,7 +323,7 @@ def get_symmetrised_systematic_uncertainty(options, norm_syst_unc_x_secs ):
             # TODO Find signs etc... i.e. do proper covariance for PDF
             normalised_x_sections_with_symmetrised_systematics[systematic] = [
                 pdf_sym, 
-                [0]*len(central_measurement),
+                pdf_sign
             ]  
         elif systematic == 'central':
             normalised_x_sections_with_symmetrised_systematics['central'] = central_measurement

--- a/dps/utils/systematic.py
+++ b/dps/utils/systematic.py
@@ -353,11 +353,12 @@ def get_symmetrised_systematic_uncertainty(options, norm_syst_unc_x_secs ):
     normalised_x_sections_with_symmetrised_systematics['BJet'][0] = bJet_tot
 
     # Combine PDF with alphaS variations
-    alphaS = normalised_x_sections_with_symmetrised_systematics['TTJets_alphaS'][0]
-    pdf = normalised_x_sections_with_symmetrised_systematics['PDF'][0]
-    pdf_tot = [combine_errors_in_quadrature([e1, e2]) for e1, e2 in zip(alphaS, pdf)]
-    normalised_x_sections_with_symmetrised_systematics['PDF'][0] = pdf_tot
-    # TODO combine the signs....
+    if 'TTJets_alphaS' in normalised_x_sections_with_symmetrised_systematics and 'PDF' in normalised_x_sections_with_symmetrised_systematics:
+        alphaS = normalised_x_sections_with_symmetrised_systematics['TTJets_alphaS'][0]
+        pdf = normalised_x_sections_with_symmetrised_systematics['PDF'][0]
+        pdf_tot = [combine_errors_in_quadrature([e1, e2]) for e1, e2 in zip(alphaS, pdf)]
+        normalised_x_sections_with_symmetrised_systematics['PDF'][0] = pdf_tot
+        # TODO combine the signs....
 
     # Now alphaS is combined with pdfs dont need it in dictionary anymore. nor LightJet
     del normalised_x_sections_with_symmetrised_systematics['LightJet']


### PR DESCRIPTION
Debugging the covariance matrices.

- Only store covariance and correlation matrices for unfolded number of events immediately after unfolding.  Propagate covariance matrix at the same time as actually calculating the normalised cross section (avoids code duplication).

- Get covariance matrix arising from statistical uncertainties in input data, and ignore statistical uncertainty from response matrix, as this is compatible with uncertainties on the unfolded data histogram (to be discussed)

- Add sign to pdf uncertainty, sign of mean( central - variation )

- Some bugs e.g. using bin edges rather than bin widths, adding correlation matrices.