### PR TITLE
amc/madgraph bug in 02_unfold_and_measure.py

### DIFF
--- a/dps/analysis/xsection/02_unfold_and_measure.py
+++ b/dps/analysis/xsection/02_unfold_and_measure.py
@@ -390,8 +390,8 @@ def get_unfolded_normalisation( TTJet_normalisation_results, category, channel, 
 
     
         normalisation_unfolded['powhegPythia8'] = hist_to_value_error_tuplelist( h_truth_powhegPythia8 )
-        # normalisation_unfolded['amcatnlo']      = hist_to_value_error_tuplelist( h_truth_madgraphMLM )
-        # normalisation_unfolded['madgraphMLM']   = hist_to_value_error_tuplelist( h_truth_amcatnlo )
+        # normalisation_unfolded['amcatnlo']      = hist_to_value_error_tuplelist( h_truth_amcatnlo )
+        # normalisation_unfolded['madgraphMLM']   = hist_to_value_error_tuplelist( h_truth_madgraphMLM )
         normalisation_unfolded['powhegHerwig']  = hist_to_value_error_tuplelist( h_truth_powheg_herwig )
 
         normalisation_unfolded['massdown']      = hist_to_value_error_tuplelist( h_truth_massdown )


### PR DESCRIPTION
It's commented out for now, but the unfolded normalisation for amc was being stored as madgraph, and vice versa.

Also trying out modifying files in our repository via web browser.