### PR TITLE
Lepton eta

### DIFF
--- a/bin/dice_01
+++ b/bin/dice_01
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo "Recreating Config Files (Just in case you forgot...)"
-python dps/analysis/xsection/create_measurement.py
+# python dps/analysis/xsection/create_measurement.py
 echo "Tarring DailyPythonScripts..."
-tar -cf dps.tar ../DailyPythonScripts/ --exclude ../DailyPythonScripts/data --exclude ../DailyPythonScripts/plots --exclude ../DailyPythonScripts/tables  --exclude ../DailyPythonScripts/jobs --exclude ../DailyPythonScripts/unfolding --exclude ../DailyPythonScripts/dps.tar
+tar -cf dps.tar ../DailyPythonScripts/ --exclude ../DailyPythonScripts/.git --exclude ../DailyPythonScripts/data --exclude ../DailyPythonScripts/plots --exclude ../DailyPythonScripts/tables  --exclude ../DailyPythonScripts/jobs --exclude ../DailyPythonScripts/unfolding --exclude ../DailyPythonScripts/dps.tar 
 echo "Submitting jobs to DICE..."
 condor_submit dps/experimental/condor/01b/01_fit.description
 echo "Done."

--- a/bin/x_02b_all_vars
+++ b/bin/x_02b_all_vars
@@ -16,7 +16,7 @@ i=0
 
 
 echo "Visible phase space"
-for var in MET HT ST WPT lepton_pt abs_lepton_eta NJets; do
+for var in MET HT ST WPT lepton_pt abs_lepton_eta abs_lepton_eta_coarse NJets; do
 	echo "Unfolding distribution: $var"
 	nohup time python dps/analysis/xsection/02_unfold_and_measure.py --visiblePS -v $var -c 13 -p data/normalisation/background_subtraction/ &> logs/02_${var}_Vis_unfold_13TeV.log &
 	let i+=1

--- a/bin/x_03b_all_vars
+++ b/bin/x_03b_all_vars
@@ -13,7 +13,7 @@ N_JOBS=4
 i=0
 
 echo "Visible phase space"
-for var in MET HT ST WPT lepton_pt abs_lepton_eta NJets; do
+for var in MET HT ST WPT lepton_pt abs_lepton_eta abs_lepton_eta_coarse NJets; do
 	echo "Calculating diff. x-section for distribution: $var"
 	nohup time python dps/analysis/xsection/03_calculate_systematics.py --visiblePS -s -v $var -c 13 -u TUnfold -p data/normalisation/background_subtraction/ &> logs/03_${var}_calculate_Vis_13TeV.log &
 	let i+=1

--- a/bin/x_04b_all_vars
+++ b/bin/x_04b_all_vars
@@ -13,7 +13,7 @@ N_JOBS=4
 
 i=0
 echo "Visible phase space"
-for var in MET HT ST WPT lepton_pt abs_lepton_eta NJets; do
+for var in MET HT ST WPT lepton_pt abs_lepton_eta abs_lepton_eta_coarse NJets; do
 	echo "Plotting diff. x-section for distribution: $var"
 	nohup time python dps/analysis/xsection/04_make_plots_matplotlib.py --visiblePS -v $var -c 13 -p data/normalisation/background_subtraction/ -o plots/background_subtraction -r &> logs/04_${var}_plot_Vis_13TeV.log & # -a  <--add this option for additional plots
 	let i+=1

--- a/bin/x_04b_all_vars
+++ b/bin/x_04b_all_vars
@@ -15,7 +15,7 @@ i=0
 echo "Visible phase space"
 for var in MET HT ST WPT lepton_pt abs_lepton_eta NJets; do
 	echo "Plotting diff. x-section for distribution: $var"
-	nohup time python dps/analysis/xsection/04_make_plots_matplotlib.py --visiblePS --show-generator-ratio -v $var -c 13 -p data/normalisation/background_subtraction/ -o plots/background_subtraction -r &> logs/04_${var}_plot_Vis_13TeV.log & # -a  <--add this option for additional plots
+	nohup time python dps/analysis/xsection/04_make_plots_matplotlib.py --visiblePS -v $var -c 13 -p data/normalisation/background_subtraction/ -o plots/background_subtraction -r &> logs/04_${var}_plot_Vis_13TeV.log & # -a  <--add this option for additional plots
 	let i+=1
 	shallIwait $i $N_JOBS
 done

--- a/bin/x_05b_all_vars
+++ b/bin/x_05b_all_vars
@@ -18,7 +18,7 @@ i=0
 
 echo "Now visible phase space"
 
-for var in MET HT ST WPT lepton_pt abs_lepton_eta NJets; do
+for var in MET HT ST WPT lepton_pt abs_lepton_eta abs_lepton_eta_coarse NJets; do
 	echo "Tabulating diff. x-section for distribution: $var"
 	nohup time python dps/analysis/xsection/05_make_systematic_plots.py -v $var --visiblePS &> logs/05_${var}_table_13TeV.log &
 	let i+=1

--- a/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
+++ b/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
@@ -97,7 +97,7 @@ def getFileName( com, sample, measurementConfig ) :
             'central_firstHalf'           : measurementConfig.ttbar_trees,
             'central_secondHalf'           : measurementConfig.ttbar_trees,
 
-            'amcatnlo'          : measurementConfig.ttbar_amc_trees,
+            'amcatnloPythia8'          : measurementConfig.ttbar_amc_trees,
             'madgraph'          : measurementConfig.ttbar_madgraph_trees,
             'powhegherwigpp'    : measurementConfig.ttbar_powhegherwigpp_trees,
 

--- a/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
+++ b/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
@@ -332,8 +332,6 @@ def main():
     if args.newPS :
         outputFileName = outputFileName.replace('asymmetric','asymmetric_newPS')
 
-    # outputFileName = outputFileName.replace('asymmetric','asymmetric_AlternativeWeightAndCorrection')
-
     # Get the tree/chain
     treeName = "TTbar_plus_X_analysis/Unfolding/Unfolding"
     print file_name
@@ -835,7 +833,7 @@ def main():
         # Done all channels, now combine the two channels, and output to the same file
         for path, dirs, objects in out.walk():
             if 'electron' in path:
-                if 'Bins' in path or 'coarse' in path: continue
+                if 'coarse' in path: continue
                 outputDir = out.mkdir(path.replace('electron','combined'))
                 outputDir.cd()
                 for h in objects:

--- a/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
+++ b/dps/analysis/BLTUnfold/produceUnfoldingHistograms.py
@@ -76,7 +76,6 @@ def getUnmergedDirectory( f ) :
         sampleName = 'TTJets_madgraphMLM'
     new_f = None
     if 'plusJES' in f:
-        print 'HERE',sampleName.strip('_plusJES')
         new_f = baseDir + '/' + sampleName.strip('_plusJES') + '/analysis_JES_up_job_*/*root'
     elif 'minusJES' in f:
         new_f = baseDir + '/' + sampleName.strip('_minusJES') + '/analysis_JES_down_job_*/*root'
@@ -533,7 +532,7 @@ def main():
                 branch = event.__getattr__
                 n+=1
                 if not n%100000: print 'Processing event %.0f Progress : %.2g %%' % ( n, float(n)/nEntries*100 )
-                # if n > 100000: break
+                # if n > 1000000: break
 
                 if maxEvents > 0 and n > maxEvents: break
 
@@ -565,10 +564,10 @@ def main():
                     leptonWeight = event.LeptonEfficiencyCorrectionDown
 
                 # B Jet Weight
-                # bjetWeight = event.BJetWeight
-                bjetWeight = event.BJetAlternativeWeight
+                bjetWeight = event.BJetWeight
+                # bjetWeight = event.BJetAlternativeWeight
                 if 'fsr' in args.sample:
-                    bjetWeight = event.BJetAlternativeWeight * event.BJetEfficiencyCorrectionWeight
+                    bjetWeight = event.BJetWeight * event.BJetEfficiencyCorrectionWeight
 
                 if args.sample == "bjetup":
                     bjetWeight = event.BJetUpWeight
@@ -599,7 +598,6 @@ def main():
 
                 if MMHT14Weight >= 0:
                     genWeight *= branch('MMHT14Weight_%i' % MMHT14Weight)
-                    print genWeight
                     pass
 
 

--- a/dps/analysis/BLTUnfold/runJobsCrab.py
+++ b/dps/analysis/BLTUnfold/runJobsCrab.py
@@ -76,8 +76,10 @@ jobs = [
         '--centreOfMassEnergy 13 -s jerup',
         '--centreOfMassEnergy 13 -s jerdown',
 
-        '--centreOfMassEnergy 13 -s leptonup',
-        '--centreOfMassEnergy 13 -s leptondown',
+        '--centreOfMassEnergy 13 -s electronup',
+        '--centreOfMassEnergy 13 -s electrondown',
+        '--centreOfMassEnergy 13 -s muonup',
+        '--centreOfMassEnergy 13 -s muondown',
 
         '--centreOfMassEnergy 13 -s bjetup',
         '--centreOfMassEnergy 13 -s bjetdown',

--- a/dps/analysis/BLTUnfold/runJobsCrab.py
+++ b/dps/analysis/BLTUnfold/runJobsCrab.py
@@ -17,7 +17,7 @@ jobs = [
         # '--centreOfMassEnergy 13 -s central_firstHalf --topPtReweighting -1',
         # '--centreOfMassEnergy 13 -s central_secondHalf --topPtReweighting -1',
 
-        '--centreOfMassEnergy 13 -s amcatnlo',
+        '--centreOfMassEnergy 13 -s amcatnloPythia8',
         '--centreOfMassEnergy 13 -s madgraph',
         '--centreOfMassEnergy 13 -s powhegherwigpp',
 

--- a/dps/analysis/BLTUnfold/runJobsCrab.py
+++ b/dps/analysis/BLTUnfold/runJobsCrab.py
@@ -5,17 +5,17 @@ from copy import deepcopy
 
 jobs = [
         # # 13 TeV
-        '--centreOfMassEnergy 13 -f',
+        # '--centreOfMassEnergy 13 -f',
 
         '--centreOfMassEnergy 13 -s central',
 
-        '--centreOfMassEnergy 13 -s central_firstHalf',
-        '--centreOfMassEnergy 13 -s central_secondHalf',
+        # '--centreOfMassEnergy 13 -s central_firstHalf',
+        # '--centreOfMassEnergy 13 -s central_secondHalf',
 
-        '--centreOfMassEnergy 13 -s central_firstHalf --topPtReweighting 1',
-        '--centreOfMassEnergy 13 -s central_secondHalf --topPtReweighting 1',
-        '--centreOfMassEnergy 13 -s central_firstHalf --topPtReweighting -1',
-        '--centreOfMassEnergy 13 -s central_secondHalf --topPtReweighting -1',
+        # '--centreOfMassEnergy 13 -s central_firstHalf --topPtReweighting 1',
+        # '--centreOfMassEnergy 13 -s central_secondHalf --topPtReweighting 1',
+        # '--centreOfMassEnergy 13 -s central_firstHalf --topPtReweighting -1',
+        # '--centreOfMassEnergy 13 -s central_secondHalf --topPtReweighting -1',
 
         '--centreOfMassEnergy 13 -s amcatnlo',
         '--centreOfMassEnergy 13 -s madgraph',
@@ -55,17 +55,17 @@ jobs = [
         '--centreOfMassEnergy 13 --alphaSWeight 0',
         '--centreOfMassEnergy 13 --alphaSWeight 1',
 
-        # # B fragmentation weights
+        # B fragmentation weights
         '--centreOfMassEnergy 13 --fragWeight 1',
         '--centreOfMassEnergy 13 --fragWeight 2',
         '--centreOfMassEnergy 13 --fragWeight 3',
         '--centreOfMassEnergy 13 --fragWeight 4',
 
-        # # Semileptonic BR
+        # Semileptonic BR
         '--centreOfMassEnergy 13 --semiLepBrWeight -1',
         '--centreOfMassEnergy 13 --semiLepBrWeight 1',
 
-        # # Top mass
+        # Top mass
         '--centreOfMassEnergy 13 -s massup',
         '--centreOfMassEnergy 13 -s massdown',
 
@@ -107,21 +107,22 @@ while variation <= maxPDF :
     variation += 1
     pass
 
-maxPDF = 54
-variation = minPDF
-while variation <= maxPDF :
-    jobs.append('--centreOfMassEnergy 13 --CT14Weight {} '.format(variation) )
-    variation += 1
-    pass
+# maxPDF = 54
+# variation = minPDF
+# while variation <= maxPDF :
+#     jobs.append('--centreOfMassEnergy 13 --CT14Weight {} '.format(variation) )
+#     variation += 1
+#     pass
 
-maxPDF = 55
-variation = minPDF
-while variation <= maxPDF :
-    jobs.append('--centreOfMassEnergy 13 --MMHT14Weight {} '.format(variation) )
-    variation += 1
-    pass
+# maxPDF = 55
+# variation = minPDF
+# while variation <= maxPDF :
+#     jobs.append('--centreOfMassEnergy 13 --MMHT14Weight {} '.format(variation) )
+#     variation += 1
+#     pass
 
-jobsWithNewPS = deepcopy( jobs )
+# jobsWithNewPS = deepcopy( jobs )
+jobsWithNewPS = []
 for job in jobs:
     jobsWithNewPS.append( job + ' --newPS')
 jobs = jobsWithNewPS

--- a/dps/analysis/BLTUnfold/submitBLTUnfold.description
+++ b/dps/analysis/BLTUnfold/submitBLTUnfold.description
@@ -16,4 +16,4 @@ request_memory=500
 # use the ENV that is provided
 getenv = true
 
-queue 152
+queue 154

--- a/dps/analysis/BLTUnfold/submitBLTUnfold.description
+++ b/dps/analysis/BLTUnfold/submitBLTUnfold.description
@@ -16,4 +16,4 @@ request_memory=500
 # use the ENV that is provided
 getenv = true
 
-queue 540
+queue 152

--- a/dps/analysis/xsection/01_get_ttjet_normalisation.py
+++ b/dps/analysis/xsection/01_get_ttjet_normalisation.py
@@ -33,7 +33,7 @@ def main():
 
     for ch in channels:
         for var in measurement_config.variables:
-            if args.variable not in var: continue
+            if not args.variable == var: continue
             qcd_transfer_factor = {}
 
             # Create measurement_filepath

--- a/dps/analysis/xsection/02_unfold_and_measure.py
+++ b/dps/analysis/xsection/02_unfold_and_measure.py
@@ -84,8 +84,10 @@ def get_unfolding_files(measurement_config):
     unfolding_files['file_for_lightjetdown']        = File( measurement_config.unfolding_lightjet_down, 'read' )
     unfolding_files['file_for_lightjetup']          = File( measurement_config.unfolding_lightjet_up, 'read' )
 
-    unfolding_files['file_for_LeptonDown']          = File( measurement_config.unfolding_Lepton_down, 'read' )
-    unfolding_files['file_for_LeptonUp']            = File( measurement_config.unfolding_Lepton_up, 'read' )
+    unfolding_files['file_for_ElectronDown']          = File( measurement_config.unfolding_Electron_down, 'read' )
+    unfolding_files['file_for_ElectronUp']            = File( measurement_config.unfolding_Electron_up, 'read' )
+    unfolding_files['file_for_MuonDown']          = File( measurement_config.unfolding_Muon_down, 'read' )
+    unfolding_files['file_for_MuonUp']            = File( measurement_config.unfolding_Muon_up, 'read' )
 
     unfolding_files['file_for_ElectronEnDown']      = File( measurement_config.unfolding_ElectronEn_down, 'read' )
     unfolding_files['file_for_ElectronEnUp']        = File( measurement_config.unfolding_ElectronEn_up, 'read' )
@@ -227,10 +229,10 @@ def get_unfolded_normalisation( TTJet_normalisation_results, category, channel, 
         'UnclusteredEnUp'            :  unfolding_files['file_for_UnclusteredEnUp'],
         'UnclusteredEnDown'          :  unfolding_files['file_for_UnclusteredEnDown'],
 
-        'Muon_up'                    :  unfolding_files['file_for_LeptonUp'],
-        'Muon_down'                  :  unfolding_files['file_for_LeptonDown'],
-        'Electron_up'                :  unfolding_files['file_for_LeptonUp'],
-        'Electron_down'              :  unfolding_files['file_for_LeptonDown'],
+        'Muon_up'                    :  unfolding_files['file_for_ElectronUp'],
+        'Muon_down'                  :  unfolding_files['file_for_ElectronDown'],
+        'Electron_up'                :  unfolding_files['file_for_MuonUp'],
+        'Electron_down'              :  unfolding_files['file_for_MuonDown'],
 
         'PileUp_up'                  :  unfolding_files['file_for_PUUp'],
         'PileUp_down'                :  unfolding_files['file_for_PUDown'],

--- a/dps/analysis/xsection/02_unfold_and_measure.py
+++ b/dps/analysis/xsection/02_unfold_and_measure.py
@@ -1303,19 +1303,19 @@ if __name__ == '__main__':
         calculate_normalised_xsections( unfolded_normalisation_muon, category, channel, covariance_matrix=covariance_muon, input_mc_covariance_matrix = inputMC_covariance_muon )
         calculate_normalised_xsections( unfolded_normalisation_muon, category, channel , True )
 
-        # Results where the channels are combined before unfolding (the 'combined in the response matrix')
-        channel = 'combinedBeforeUnfolding'
-        unfolded_normalisation_combinedBeforeUnfolding, covariance_combinedBeforeUnfolding, inputMC_covariance_combinedBeforeUnfolding = get_unfolded_normalisation(
-            TTJet_normalisation_results_combined,
-            category,
-            'combined', 
-            tau_value=tau_value_combined,
-            visiblePS=visiblePS,
-        )
-        # measure xsection
-        calculate_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel, covariance_matrix=covariance_combinedBeforeUnfolding, input_mc_covariance_matrix = inputMC_covariance_combinedBeforeUnfolding  )
-        calculate_normalised_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel, covariance_matrix=covariance_combinedBeforeUnfolding, input_mc_covariance_matrix = inputMC_covariance_combinedBeforeUnfolding )
-        calculate_normalised_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel , True )
+        # # Results where the channels are combined before unfolding (the 'combined in the response matrix')
+        # channel = 'combinedBeforeUnfolding'
+        # unfolded_normalisation_combinedBeforeUnfolding, covariance_combinedBeforeUnfolding, inputMC_covariance_combinedBeforeUnfolding = get_unfolded_normalisation(
+        #     TTJet_normalisation_results_combined,
+        #     category,
+        #     'combined', 
+        #     tau_value=tau_value_combined,
+        #     visiblePS=visiblePS,
+        # )
+        # # measure xsection
+        # calculate_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel, covariance_matrix=covariance_combinedBeforeUnfolding, input_mc_covariance_matrix = inputMC_covariance_combinedBeforeUnfolding  )
+        # calculate_normalised_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel, covariance_matrix=covariance_combinedBeforeUnfolding, input_mc_covariance_matrix = inputMC_covariance_combinedBeforeUnfolding )
+        # calculate_normalised_xsections( unfolded_normalisation_combinedBeforeUnfolding, category, channel , True )
 
         # Results where the channels are combined after unfolding
         channel = 'combined'

--- a/dps/analysis/xsection/02_unfold_and_measure.py
+++ b/dps/analysis/xsection/02_unfold_and_measure.py
@@ -104,7 +104,7 @@ def get_unfolding_files(measurement_config):
     unfolding_files['file_for_ptreweight']          = File( measurement_config.unfolding_ptreweight, 'read' )
 
     unfolding_files['file_for_powhegPythia8']       = File( measurement_config.unfolding_powheg_pythia8, 'read')
-    unfolding_files['file_for_amcatnlo']            = File( measurement_config.unfolding_amcatnlo, 'read')
+    unfolding_files['file_for_amcatnloPythia8']            = File( measurement_config.unfolding_amcatnlo_pythia8, 'read')
     unfolding_files['file_for_madgraphMLM']         = File( measurement_config.unfolding_madgraphMLM, 'read')
     unfolding_files['file_for_powheg_herwig']       = File( measurement_config.unfolding_powheg_herwig, 'read' )
     return unfolding_files
@@ -420,8 +420,8 @@ def get_unfolded_normalisation( TTJet_normalisation_results, category, channel, 
             load_fakes = True,
             visiblePS = visiblePS,
         )
-        h_truth_amcatnlo, _, _, _ = get_unfold_histogram_tuple( 
-            inputfile = unfolding_files['file_for_amcatnlo'],
+        h_truth_amcatnloPythia8, _, _, _ = get_unfold_histogram_tuple( 
+            inputfile = unfolding_files['file_for_amcatnloPythia8'],
             variable = variable,
             channel = channel,
             centre_of_mass = com,
@@ -642,7 +642,7 @@ def get_unfolded_normalisation( TTJet_normalisation_results, category, channel, 
         )   
 
         normalisation_unfolded['TTJets_powhegPythia8'] = hist_to_value_error_tuplelist( h_truth_powhegPythia8 )
-        normalisation_unfolded['TTJets_amcatnlo']      = hist_to_value_error_tuplelist( h_truth_amcatnlo )
+        normalisation_unfolded['TTJets_amcatnloPythia8']      = hist_to_value_error_tuplelist( h_truth_amcatnloPythia8 )
         normalisation_unfolded['TTJets_madgraphMLM']   = hist_to_value_error_tuplelist( h_truth_madgraphMLM )
         normalisation_unfolded['TTJets_powhegHerwig']  = hist_to_value_error_tuplelist( h_truth_powheg_herwig )
 
@@ -741,8 +741,8 @@ def calculate_xsections( normalisation, category, channel, covariance_matrix=Non
             luminosity, 
             branching_ratio 
         )
-        xsection_unfolded['TTJets_amcatnlo'], _, _, _ = calculate_xsection( 
-            normalisation['TTJets_amcatnlo'],
+        xsection_unfolded['TTJets_amcatnloPythia8'], _, _, _ = calculate_xsection( 
+            normalisation['TTJets_amcatnloPythia8'],
             binWidths[variable],
             luminosity, 
             branching_ratio 
@@ -975,8 +975,8 @@ def calculate_normalised_xsections( normalisation, category, channel, normalise_
             binWidths[variable], 
             normalise_to_one, 
         )
-        normalised_xsection['TTJets_amcatnlo'], _, _, _ = calculate_normalised_xsection( 
-            normalisation['TTJets_amcatnlo'], 
+        normalised_xsection['TTJets_amcatnloPythia8'], _, _, _ = calculate_normalised_xsection( 
+            normalisation['TTJets_amcatnloPythia8'], 
             binWidths[variable], 
             normalise_to_one, 
         )

--- a/dps/analysis/xsection/04_make_plots_matplotlib.py
+++ b/dps/analysis/xsection/04_make_plots_matplotlib.py
@@ -100,7 +100,7 @@ def read_xsection_measurement_results( category, channel, unc_type, scale_uncert
     if category == 'central':
         # Add in distributions for the different MC to be shown
         h_normalised_xsection_powhegPythia8     = value_error_tuplelist_to_hist( normalised_xsection_unfolded['TTJets_powhegPythia8'], edges )
-        h_normalised_xsection_amcatnlo          = value_error_tuplelist_to_hist( normalised_xsection_unfolded['TTJets_amcatnlo'], edges )
+        h_normalised_xsection_amcatnlo          = value_error_tuplelist_to_hist( normalised_xsection_unfolded['TTJets_amcatnloPythia8'], edges )
         h_normalised_xsection_madgraphMLM       = value_error_tuplelist_to_hist( normalised_xsection_unfolded['TTJets_madgraphMLM'], edges )
         h_normalised_xsection_powhegHerwigpp    = value_error_tuplelist_to_hist( normalised_xsection_unfolded['TTJets_powhegHerwig'], edges )
         # SCALE BREAKDOWN

--- a/dps/analysis/xsection/04_make_plots_matplotlib.py
+++ b/dps/analysis/xsection/04_make_plots_matplotlib.py
@@ -461,7 +461,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = Fals
         legend_location = (0.97, 0.82)
     elif variable == 'WPT':
         legend_location = (1.0, 0.84)
-    elif variable == 'abs_lepton_eta':
+    elif variable == 'abs_lepton_eta' or variable =='abs_lepton_eta_coarse':
         legend_location = (0.97, 0.87)
     elif variable == 'NJets':
         # Reduce size of NJets legend
@@ -529,7 +529,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = Fals
     if ylim[0] < 0:
         axes.set_ylim( ymin = 0.)
     axes.set_ylim(ymax = ylim[1]*1.1)
-    if variable == 'abs_lepton_eta':
+    if variable == 'abs_lepton_eta' or variable == 'abs_lepton_eta_coarse':
         axes.set_ylim(ymax = ylim[1]*1.6)
 
     # Now to show either of the ratio plots
@@ -626,7 +626,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = Fals
             loc = 'lower left'
         elif variable == 'NJets':
             loc = 'lower left'
-        elif variable == 'abs_lepton_eta':
+        elif variable == 'abs_lepton_eta' or variable == 'abs_lepton_eta_coarse':
             loc = 'upper left'
         elif variable == 'lepton_pt':
             loc = 'lower left'
@@ -668,7 +668,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = Fals
             ax1.set_ylim( ymin = 0.6, ymax = 1.4 )
             ax1.yaxis.set_major_locator( MultipleLocator( 0.2 ) )
             ax1.yaxis.set_minor_locator( MultipleLocator( 0.1 ) )
-        elif variable == 'abs_lepton_eta':
+        elif variable == 'abs_lepton_eta' or variable == 'abs_lepton_eta_coarse':
             ax1.set_ylim( ymin = 0.6, ymax = 1.4 )
             ax1.yaxis.set_major_locator( MultipleLocator( 0.2 ) )
             ax1.yaxis.set_minor_locator( MultipleLocator( 0.1 ) )
@@ -793,7 +793,7 @@ def make_plots( histograms, category, output_folder, histname, show_ratio = Fals
             ax2.yaxis.set_minor_locator( MultipleLocator( 0.1 ) )
         elif variable == 'NJets':
             ax2.set_ylim( ymin = 0.7, ymax = 1.5 )
-        elif variable == 'abs_lepton_eta':
+        elif variable == 'abs_lepton_eta' or variable == 'abs_lepton_eta_coarse':
             ax2.set_ylim( ymin = 0.8, ymax = 1.2 )
             ax2.yaxis.set_major_locator( MultipleLocator( 0.2 ) )
             ax2.yaxis.set_minor_locator( MultipleLocator( 0.1 ) )

--- a/dps/analysis/xsection/06_calculate_chi2.py
+++ b/dps/analysis/xsection/06_calculate_chi2.py
@@ -44,6 +44,7 @@ def calculateGlobalChi2(modelsForComparing, chi2_Models):
 def calculateChi2ForModels( modelsForComparing, variable, channel, path_to_input, uncertainty_type ):
 	# Paths to statistical Covariance/Correlation matrices.
 	covariance_filename = '{input_path}/covarianceMatrices/{type}/Total_Covariance_{channel}.txt'.format(input_path=path_to_input, type = uncertainty_type, channel=channel)
+
 	# Convert to numpy matrix and create total
 	cov_full = matrix_from_df( file_to_df(covariance_filename) )
 
@@ -201,8 +202,8 @@ if __name__ == '__main__':
 	    phase_space = 'VisiblePS'
 
 	channels = [
-		# 'electron', 
-		# 'muon', 
+		'electron', 
+		'muon', 
 		'combined', 
 		# 'combinedBeforeUnfolding',
 	]

--- a/dps/analysis/xsection/create_measurement.py
+++ b/dps/analysis/xsection/create_measurement.py
@@ -153,8 +153,8 @@ def get_sample_info(options, xsec_config, sample):
 
     # Bin Edges
     if options['control_plot_binning']:
-        firstBin = variable_binning.control_plots_bins[options['variable']][0]
-        lastBin = variable_binning.control_plots_bins[options['variable']][-1]
+        firstBin = variable_binning.control_plots_bins_for01[options['variable']][0]
+        lastBin = variable_binning.control_plots_bins_for01[options['variable']][-1]
         nBins = variable_binning.control_plot_nbins[options['variable']]
         binWidth =  ( lastBin - firstBin ) / nBins
         sample_info["bin_edges"] =  [ firstBin + i * binWidth for i in range(0, nBins+1) ]
@@ -231,12 +231,20 @@ def get_sample_info(options, xsec_config, sample):
         # Lepton weights for nonisolated leptons are removed in measurement.py
         # The lepton sf are not derived for non isolated leptons
         if options['channel'] == 'muon':
-            if options['category'] == 'Muon_down':
-                weight_branches.append('MuonDown')
-            elif options['category'] == 'Muon_up':
-                weight_branches.append('MuonUp')
+            if options['variable'] == 'abs_lepton_eta':
+                if options['category'] == 'Muon_down':
+                    weight_branches.append('MuonDown_etaBins')
+                elif options['category'] == 'Muon_up':
+                    weight_branches.append('MuonUp_etaBins')
+                else:
+                    weight_branches.append('MuonEfficiencyCorrection_etaBins')
             else:
-                weight_branches.append('MuonEfficiencyCorrection')
+                if options['category'] == 'Muon_down':
+                    weight_branches.append('MuonDown')
+                elif options['category'] == 'Muon_up':
+                    weight_branches.append('MuonUp')
+                else:
+                    weight_branches.append('MuonEfficiencyCorrection')
         elif options['channel'] == 'electron':
             if options['category'] == 'Electron_down':
                 weight_branches.append('ElectronDown')

--- a/dps/analysis/xsection/create_measurement.py
+++ b/dps/analysis/xsection/create_measurement.py
@@ -231,7 +231,7 @@ def get_sample_info(options, xsec_config, sample):
         # Lepton weights for nonisolated leptons are removed in measurement.py
         # The lepton sf are not derived for non isolated leptons
         if options['channel'] == 'muon':
-            if options['variable'] == 'abs_lepton_eta':
+            if 'abs_lepton_eta' in options['variable']:
                 if options['category'] == 'Muon_down':
                     weight_branches.append('MuonDown_etaBins')
                 elif options['category'] == 'Muon_up':

--- a/dps/analysis/xsection/create_measurement.py
+++ b/dps/analysis/xsection/create_measurement.py
@@ -246,12 +246,20 @@ def get_sample_info(options, xsec_config, sample):
                 else:
                     weight_branches.append('MuonEfficiencyCorrection')
         elif options['channel'] == 'electron':
-            if options['category'] == 'Electron_down':
-                weight_branches.append('ElectronDown')
-            elif options['category'] == 'Electron_up':
-                weight_branches.append('ElectronUp')
+            if 'abs_lepton_eta' in options['variable']:
+                if options['category'] == 'Electron_down':
+                    weight_branches.append('ElectronDown_etaBins')
+                elif options['category'] == 'Electron_up':
+                    weight_branches.append('ElectronUp_etaBins')
+                else:
+                    weight_branches.append('ElectronEfficiencyCorrection_etaBins')
             else:
-                weight_branches.append('ElectronEfficiencyCorrection')
+                if options['category'] == 'Electron_down':
+                    weight_branches.append('ElectronDown')
+                elif options['category'] == 'Electron_up':
+                    weight_branches.append('ElectronUp')
+                else:
+                    weight_branches.append('ElectronEfficiencyCorrection')
     sample_info["weight_branches"] = weight_branches
 
     # Input File and Tree

--- a/dps/analysis/xsection/make_control_plots_from01.py
+++ b/dps/analysis/xsection/make_control_plots_from01.py
@@ -200,21 +200,19 @@ config = XSectionConfig(13)
 
 
 for variable in config.variables:
-    if not 'Bins' in variable: continue
     print variable
 
     histogramsForEachChannel = {}
     uncertaintiesForEachChannel = {}
 
     binEdges = control_plots_bins_for01[variable]
-    # bin_low = binEdges[0]
-    # bin_high = binEdges[-1]
-    # nBins = control_plot_nbins[variable] 
-    # binWidth = ( bin_high - bin_low ) / nBins
+    bin_low = binEdges[0]
+    bin_high = binEdges[-1]
+    nBins = control_plot_nbins[variable] 
+    binWidth = ( bin_high - bin_low ) / nBins
 
-    # reco_bin_edges = [ bin_low + binWidth * i for i in range(0, nBins + 1) ]
-    reco_bin_edges = binEdges
-    print reco_bin_edges
+    reco_bin_edges = [ bin_low + binWidth * i for i in range(0, nBins + 1) ]
+
     for channel in config.analysis_types.keys():
         if channel == 'combined': continue
 

--- a/dps/analysis/xsection/make_control_plots_from01.py
+++ b/dps/analysis/xsection/make_control_plots_from01.py
@@ -220,7 +220,6 @@ for variable in config.variables:
         normalisation_fileName = 'normalisation_{channel}.txt'.format(channel=channel)
         normalisation_results_electron  = read_tuple_from_file( '{path}/central/{filename}'.format(path=path_to_DF,filename=normalisation_fileName)  )
 
-        print normalisation_results_electron
         dict_histograms = getHistogramsFromNormalisationResults(normalisation_results_electron, reco_bin_edges )
 
         totalMC = sumMCHistograms( dict_histograms )
@@ -261,8 +260,6 @@ for variable in config.variables:
             for i in range(0,len(uncertainties)):
                 newUncertainty = math.sqrt( combinedUncertainties[i] ** 2 + uncertainties[i] ** 2 )
                 combinedUncertainties[i] = newUncertainty
-
-    print combinedHistograms
 
     ttbarMC = combinedHistograms['TTJet']
     data = combinedHistograms['Data']

--- a/dps/analysis/xsection/make_control_plots_from01.py
+++ b/dps/analysis/xsection/make_control_plots_from01.py
@@ -200,27 +200,29 @@ config = XSectionConfig(13)
 
 
 for variable in config.variables:
-    # if not 'HT' in variable: continue
+    if not 'Bins' in variable: continue
     print variable
 
     histogramsForEachChannel = {}
     uncertaintiesForEachChannel = {}
 
     binEdges = control_plots_bins_for01[variable]
-    bin_low = binEdges[0]
-    bin_high = binEdges[-1]
-    nBins = control_plot_nbins[variable] 
-    binWidth = ( bin_high - bin_low ) / nBins
+    # bin_low = binEdges[0]
+    # bin_high = binEdges[-1]
+    # nBins = control_plot_nbins[variable] 
+    # binWidth = ( bin_high - bin_low ) / nBins
 
-    reco_bin_edges = [ bin_low + binWidth * i for i in range(0, nBins + 1) ]
-
+    # reco_bin_edges = [ bin_low + binWidth * i for i in range(0, nBins + 1) ]
+    reco_bin_edges = binEdges
+    print reco_bin_edges
     for channel in config.analysis_types.keys():
         if channel == 'combined': continue
 
-        path_to_DF = 'data/data_normalisation/normalisation/background_subtraction/13TeV/{variable}/VisiblePS/'.format( variable = variable )
+        path_to_DF = 'data/normalisation/background_subtraction/13TeV/{variable}/VisiblePS/'.format( variable = variable )
         normalisation_fileName = 'normalisation_{channel}.txt'.format(channel=channel)
         normalisation_results_electron  = read_tuple_from_file( '{path}/central/{filename}'.format(path=path_to_DF,filename=normalisation_fileName)  )
 
+        print normalisation_results_electron
         dict_histograms = getHistogramsFromNormalisationResults(normalisation_results_electron, reco_bin_edges )
 
         totalMC = sumMCHistograms( dict_histograms )

--- a/dps/analysis/xsection/make_control_plots_fromTrees.py
+++ b/dps/analysis/xsection/make_control_plots_fromTrees.py
@@ -51,7 +51,6 @@ def getHistograms( histogram_files,
 
     # Channel specific files and weights
     if 'electron' in channel:
-        print measurement_config.data_file_electron
         histogram_files['data'] = measurement_config.data_file_electron
         histogram_files['QCD']  = measurement_config.electron_QCD_MC_trees
         if use_qcd_data_region:
@@ -59,17 +58,14 @@ def getHistograms( histogram_files,
         # No Lepton Eff in QCD CR and PU distributions
         if not 'QCD' in channel:
             weightBranchSignalRegion += ' * ElectronEfficiencyCorrection'
-            # weightBranchSignalRegion += ' * ElectronUp'
 
     if 'muon' in channel:
-        print  measurement_config.data_file_muon
         histogram_files['data'] = measurement_config.data_file_muon
         histogram_files['QCD']  = measurement_config.muon_QCD_MC_trees
         if use_qcd_data_region:
             qcd_data_region     = qcd_data_region_muon
         if not 'QCD' in channel:
             weightBranchSignalRegion += ' * MuonEfficiencyCorrection'
-            # weightBranchSignalRegion += ' * MuonEfficiencyCorrection_etaBins'
     
     # Print all the weights applied to this plot 
     print "Weight applied : {}".format(weightBranchSignalRegion)
@@ -95,8 +91,6 @@ def getHistograms( histogram_files,
             trees = [signal_region_tree.replace('COMBINED','EPlusJets')], 
             branch = branchName, 
             weightBranch = weightBranchSignalRegion + ' * ElectronEfficiencyCorrection', 
-            # weightBranch = weightBranchSignalRegion + ' * ElectronDown', 
-            # weightBranch = weightBranchSignalRegion, 
             files = histogram_files_electron, 
             nBins = nBins, 
             xMin = x_limits[0], 
@@ -107,7 +101,6 @@ def getHistograms( histogram_files,
             trees = [signal_region_tree.replace('COMBINED','MuPlusJets')], 
             branch = branchName, 
             weightBranch = weightBranchSignalRegion + ' * MuonEfficiencyCorrection', 
-            # weightBranch = weightBranchSignalRegion, 
             files = histogram_files_muon, 
             nBins = nBins, 
             xMin = x_limits[0], 
@@ -279,8 +272,6 @@ def make_plot( channel, x_axis_title, y_axis_title,
     # Selections
     if branchName == 'abs(lepton_eta)' or branchName == 'lepton_eta' :
         selectionSignalRegion = 'lepton_eta > -10'
-        # selectionSignalRegion = 'lepton_eta >= 0'
-        # selectionSignalRegion = 'lepton_eta > -10 && lepton_eta <= 0'
     else:
         selectionSignalRegion = '%s >= 0' % branchName
     if "_JetPtAdd" in name_prefix:
@@ -338,8 +329,8 @@ def make_plot( channel, x_axis_title, y_axis_title,
     histogram_properties.name                   = name_prefix + b_tag_bin
     if category != 'central':
         histogram_properties.name               += '_' + category
-    # if normalise_to_data:
-    #     histogram_properties.name               += '_normToData'
+    if normalise_to_data:
+        histogram_properties.name               += '_normToData'
     if data_period != '':
         histogram_properties.name               += '_dataPeriod_{period}'.format(period=data_period)
     histogram_properties.title                  = title
@@ -530,9 +521,6 @@ if __name__ == '__main__':
         measurement_config.data_file_muon = measurement_config.data_file_muon.replace('tree','{period}_tree'.format(period=data_period))
         measurement_config.new_luminosity = measurement_config.new_luminosity_periods[data_period]
         measurement_config.luminosity_scale = float( measurement_config.new_luminosity ) / measurement_config.luminosity
-        print measurement_config.new_luminosity
-        print measurement_config.luminosity_scale
-        # normalise_to_data = True
 
     category = args.category
     generator = args.generator
@@ -547,13 +535,9 @@ if __name__ == '__main__':
         'SingleTop' : measurement_config.SingleTop_trees,
     }
 
-    # histogram_files['TTJet'] = glob.glob( getUnmergedDirectory(histogram_files['TTJet']) )
-    # print histogram_files['TTJet']
+    # If you want to run over the unmerged output from AT, you can try this:
     # histogram_files['TTJet'] = glob.glob( getUnmergedDirectory(histogram_files['TTJet']) )
 
-    # histogram_files['TTJet'] = glob.glob( getUnmergedDirectory('/hdfs/TopQuarkGroup/ec6821/1.0.12/atOutput/combined/TTJets_PowhegPythia8_tree.root') )
-
-    print histogram_files['TTJet']
     # Swap between plotting different generators
     if 'PowhegPythia8' not in generator:
         histogram_files['TTJet'] = measurement_config.ttbar_trees.replace('PowhegPythia8', generator)
@@ -577,27 +561,27 @@ if __name__ == '__main__':
 
     # comment out plots you don't want
     include_plots = [
-        # 'HT',
-        # 'MET',
-        # 'ST',
-        # 'WPT',
-        # 'NVertex',
-        # 'NVertexNoWeight',
-        # 'NVertexUp',
-        # 'NVertexDown',
-        # 'LeptonPt',
+        'HT',
+        'MET',
+        'ST',
+        'WPT',
+        'NVertex',
+        'NVertexNoWeight',
+        'NVertexUp',
+        'NVertexDown',
+        'LeptonPt',
         'LeptonEta',
-        # 'AbsLeptonEta',
-        # 'NJets',
-        # 'NBJets',
-        # 'Tau',
+        'AbsLeptonEta',
+        'NJets',
+        'NBJets',
+        'Tau',
 
-        # 'NBJetsNoWeight',
-        # 'NBJetsUp',
-        # 'NBJetsDown',
-        # 'NBJets_LightUp',
-        # 'NBJets_LightDown',
-        # 'JetPt',
+        'NBJetsNoWeight',
+        'NBJetsUp',
+        'NBJetsDown',
+        'NBJets_LightUp',
+        'NBJets_LightDown',
+        'JetPt',
         
         # 'sigmaietaieta',
 
@@ -644,9 +628,9 @@ if __name__ == '__main__':
     )
 
     for channel, label in {
-        # 'electron' : 'EPlusJets',
+        'electron' : 'EPlusJets',
         'muon'     : 'MuPlusJets',
-        # 'combined' : 'COMBINED'
+        'combined' : 'COMBINED'
         }.iteritems() : 
 
         # Set folder for this batch of plots

--- a/dps/config/latex_labels.py
+++ b/dps/config/latex_labels.py
@@ -33,8 +33,6 @@ variables_latex = {
     'lepton_pt_-': '\ensuremath{ p_{\mathrm{T}-}^\mathrm{l} }',
     'lepton_eta': '\ensuremath{ \eta^\mathrm{l} }',
     'abs_lepton_eta': '\ensuremath{ |\eta^\mathrm{l}| }',
-    'abs_lepton_eta_muonBins': '\ensuremath{ |\eta^\mathrm{l}| }',
-    'abs_lepton_eta_electronBins': '\ensuremath{ |\eta^\mathrm{l}| }',
     'abs_lepton_eta_coarse': '\ensuremath{ |\eta^\mathrm{l}| }',
     'bjets_pt': '\ensuremath{ \mathrm{b-jet} p_{\mathrm{T}} }',
     'bjets_eta': '\ensuremath{ \mathrm{b-jet} \eta }',

--- a/dps/config/latex_labels.py
+++ b/dps/config/latex_labels.py
@@ -33,6 +33,8 @@ variables_latex = {
     'lepton_pt_-': '\ensuremath{ p_{\mathrm{T}-}^\mathrm{l} }',
     'lepton_eta': '\ensuremath{ \eta^\mathrm{l} }',
     'abs_lepton_eta': '\ensuremath{ |\eta^\mathrm{l}| }',
+    'abs_lepton_eta_muonBins': '\ensuremath{ |\eta^\mathrm{l}| }',
+    'abs_lepton_eta_electronBins': '\ensuremath{ |\eta^\mathrm{l}| }',
     'bjets_pt': '\ensuremath{ \mathrm{b-jet} p_{\mathrm{T}} }',
     'bjets_eta': '\ensuremath{ \mathrm{b-jet} \eta }',
     'sigmaietaieta' : '\ensuremath{\sigma_{i\eta i \eta}}',

--- a/dps/config/latex_labels.py
+++ b/dps/config/latex_labels.py
@@ -35,6 +35,7 @@ variables_latex = {
     'abs_lepton_eta': '\ensuremath{ |\eta^\mathrm{l}| }',
     'abs_lepton_eta_muonBins': '\ensuremath{ |\eta^\mathrm{l}| }',
     'abs_lepton_eta_electronBins': '\ensuremath{ |\eta^\mathrm{l}| }',
+    'abs_lepton_eta_coarse': '\ensuremath{ |\eta^\mathrm{l}| }',
     'bjets_pt': '\ensuremath{ \mathrm{b-jet} p_{\mathrm{T}} }',
     'bjets_eta': '\ensuremath{ \mathrm{b-jet} \eta }',
     'sigmaietaieta' : '\ensuremath{\sigma_{i\eta i \eta}}',
@@ -48,6 +49,7 @@ variables_NonLatex = {
     'NJets': 'N Jets',
     'lepton_pt': 'lepton pt',
     'abs_lepton_eta': 'lepton eta',
+    'abs_lepton_eta_coarse': 'lepton eta',
 }
 
 control_plots_latex = {

--- a/dps/config/variableBranchNames.py
+++ b/dps/config/variableBranchNames.py
@@ -33,6 +33,10 @@ branchNames = {
     'lepton_pt_-': 'leptonPt',
     'lepton_eta': 'leptonEta',
     'abs_lepton_eta': 'leptonEta',
+    'abs_lepton_eta_muonBins': 'leptonEta',
+    'abs_lepton_eta_electronBins': 'leptonEta',
+    'abs_lepton_eta_coarse': 'leptonEta',
+
 }
 
 genBranchNames_particle = {
@@ -65,6 +69,9 @@ genBranchNames_particle = {
     'lepton_pt_-': 'pseudoLepton_pT',
     'lepton_eta': 'pseudoLepton_eta',
     'abs_lepton_eta': 'pseudoLepton_eta',
+    'abs_lepton_eta_muonBins': 'pseudoLepton_eta',
+    'abs_lepton_eta_electronBins': 'pseudoLepton_eta',
+    'abs_lepton_eta_coarse': 'pseudoLepton_eta',
 }
 
 genBranchNames_parton = {

--- a/dps/config/variableBranchNames.py
+++ b/dps/config/variableBranchNames.py
@@ -33,8 +33,6 @@ branchNames = {
     'lepton_pt_-': 'leptonPt',
     'lepton_eta': 'leptonEta',
     'abs_lepton_eta': 'leptonEta',
-    'abs_lepton_eta_muonBins': 'leptonEta',
-    'abs_lepton_eta_electronBins': 'leptonEta',
     'abs_lepton_eta_coarse': 'leptonEta',
 
 }
@@ -69,8 +67,6 @@ genBranchNames_particle = {
     'lepton_pt_-': 'pseudoLepton_pT',
     'lepton_eta': 'pseudoLepton_eta',
     'abs_lepton_eta': 'pseudoLepton_eta',
-    'abs_lepton_eta_muonBins': 'pseudoLepton_eta',
-    'abs_lepton_eta_electronBins': 'pseudoLepton_eta',
     'abs_lepton_eta_coarse': 'pseudoLepton_eta',
 }
 

--- a/dps/config/variable_binning.py
+++ b/dps/config/variable_binning.py
@@ -28,8 +28,6 @@ bin_edges_full = {
 'abs_lepton_eta' : [0.0, 0.14, 0.27, 0.39, 0.53, 0.65, 0.78, 0.92, 1.05, 1.16, 1.27, 1.38, 1.48, 1.62, 1.72, 1.83, 2.0, 2.4],
 
 'abs_lepton_eta_coarse' : [0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.0, 2.4],
-'abs_lepton_eta_muonBins' : [0.0, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4],
-'abs_lepton_eta_electronBins' : [0,0.8,1.4442,1.566,2.0,2.4],
 
 }
 
@@ -43,8 +41,6 @@ bin_edges_vis = {
 'abs_lepton_eta' : [0.0, 0.14, 0.27, 0.39, 0.53, 0.65, 0.78, 0.92, 1.05, 1.16, 1.27, 1.38, 1.48, 1.62, 1.72, 1.83, 2.0, 2.4],
 
 'abs_lepton_eta_coarse' : [0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.0, 2.4],
-'abs_lepton_eta_muonBins' : [0.0, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4],
-'abs_lepton_eta_electronBins' : [0,0.8,1.4442,1.566,2.0,2.4],
 
 }
 
@@ -83,7 +79,8 @@ control_plots_bins = {
     # 'LeptonEta' : [i*0.04 for i in range( -12, 13 )],
 
     
-  'AbsLeptonEta' : [i*0.1 for i in range( 0, 25 )],  
+  # 'AbsLeptonEta' : [i*0.1 for i in range( 0, 25 )],  
+  'AbsLeptonEta' : [i*0.3 for i in range( 0, 9 )],  
 
   'NBJets' : [i - 0.5 for i in range ( 0, 6 + 1 )],
   'NVertex' : [i for i in range ( 0,40 + 1 )],
@@ -112,16 +109,15 @@ control_plots_bins_for01 = {
   'Tau'             : [0,10000],
   'MT'              : [0, 900],
 
-  'abs_lepton_eta_coarse' : reco_bin_edges_vis['abs_lepton_eta_coarse'],
-  'abs_lepton_eta_muonBins' : reco_bin_edges_vis['abs_lepton_eta_muonBins'],
-  'abs_lepton_eta_electronBins' : reco_bin_edges_vis['abs_lepton_eta_electronBins'],
+  'abs_lepton_eta_coarse' : bin_edges_vis['abs_lepton_eta_coarse'],
 
 }
 
 control_plot_nbins = {
   'NJets' : 13,
   'lepton_pt' : 38,
-  'abs_lepton_eta' : 24,  
+  'abs_lepton_eta' : 24,
+  'abs_lepton_eta_coarse' : 8,
   'MET' : 39,
   'WPT' : 16,
   'HT' : 20,

--- a/dps/config/variable_binning.py
+++ b/dps/config/variable_binning.py
@@ -5,7 +5,7 @@ def produce_reco_bin_edges( gen_bin_edges ):
     reco_bin_edges[variable] = []
     for i in range(0,len(edges)-1):
       reco_bin_edges[variable].append( edges[i])
-      reco_bin_edges[variable].append( round ( edges[i] + ( edges[i+1] - edges[i] ) / 2, 1 ) )
+      reco_bin_edges[variable].append( round ( edges[i] + ( edges[i+1] - edges[i] ) / 2, 2 ) )
     reco_bin_edges[variable].append(edges[-1])
   return reco_bin_edges
 
@@ -26,6 +26,11 @@ bin_edges_full = {
 'ST' : [136.0, 315.0, 390.0, 475.0, 565.0, 665.0, 770.0, 885.0, 1010.0, 1140.0, 1285.0, 1440.0, 1615.0, 2490.0],
 'MET' : [0.0, 50.0, 105.0, 175.0, 245.0, 315.0, 565.0],
 'abs_lepton_eta' : [0.0, 0.14, 0.27, 0.39, 0.53, 0.65, 0.78, 0.92, 1.05, 1.16, 1.27, 1.38, 1.48, 1.62, 1.72, 1.83, 2.0, 2.4],
+
+'abs_lepton_eta_coarse' : [0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.0, 2.4],
+'abs_lepton_eta_muonBins' : [0.0, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4],
+'abs_lepton_eta_electronBins' : [0,0.8,1.4442,1.566,2.0,2.4],
+
 }
 
 bin_edges_vis = {
@@ -36,6 +41,11 @@ bin_edges_vis = {
 'ST' : [136.0, 315.0, 390.0, 475.0, 565.0, 665.0, 770.0, 885.0, 1010.0, 1140.0, 1285.0, 1440.0, 1615.0, 2490.0],
 'MET' : [0.0, 50.0, 105.0, 175.0, 245.0, 315.0, 565.0],
 'abs_lepton_eta' : [0.0, 0.14, 0.27, 0.39, 0.53, 0.65, 0.78, 0.92, 1.05, 1.16, 1.27, 1.38, 1.48, 1.62, 1.72, 1.83, 2.0, 2.4],
+
+'abs_lepton_eta_coarse' : [0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.0, 2.4],
+'abs_lepton_eta_muonBins' : [0.0, 0.2, 0.3, 0.9, 1.2, 1.6, 2.1, 2.4],
+'abs_lepton_eta_electronBins' : [0,0.8,1.4442,1.566,2.0,2.4],
+
 }
 
 reco_bin_edges_vis = produce_reco_bin_edges( bin_edges_vis )
@@ -67,7 +77,12 @@ control_plots_bins = {
   'MuonPt' : [i * 10 for i in range ( 1, 40 )],
   'ElectronPt' : [i * 10 for i in range ( 1, 40 )],
 
-  'LeptonEta' : [i*0.5 for i in range( -25, 25 )],  
+  'LeptonEta' : [i*0.2 for i in range( -12, 13 )],
+
+    # 'LeptonEta' : [i*0.02 for i in range( -25, 26 )],
+    # 'LeptonEta' : [i*0.04 for i in range( -12, 13 )],
+
+    
   'AbsLeptonEta' : [i*0.1 for i in range( 0, 25 )],  
 
   'NBJets' : [i - 0.5 for i in range ( 0, 6 + 1 )],
@@ -96,6 +111,11 @@ control_plots_bins_for01 = {
   'ST'              : [100,2000],
   'Tau'             : [0,10000],
   'MT'              : [0, 900],
+
+  'abs_lepton_eta_coarse' : reco_bin_edges_vis['abs_lepton_eta_coarse'],
+  'abs_lepton_eta_muonBins' : reco_bin_edges_vis['abs_lepton_eta_muonBins'],
+  'abs_lepton_eta_electronBins' : reco_bin_edges_vis['abs_lepton_eta_electronBins'],
+
 }
 
 control_plot_nbins = {

--- a/dps/config/variable_binning.py
+++ b/dps/config/variable_binning.py
@@ -75,11 +75,6 @@ control_plots_bins = {
 
   'LeptonEta' : [i*0.2 for i in range( -12, 13 )],
 
-    # 'LeptonEta' : [i*0.02 for i in range( -25, 26 )],
-    # 'LeptonEta' : [i*0.04 for i in range( -12, 13 )],
-
-    
-  # 'AbsLeptonEta' : [i*0.1 for i in range( 0, 25 )],  
   'AbsLeptonEta' : [i*0.3 for i in range( 0, 9 )],  
 
   'NBJets' : [i - 0.5 for i in range ( 0, 6 + 1 )],

--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -25,7 +25,7 @@ class XSectionConfig():
         'ttbar_theory_systematic_prefix', 'ttbar_xsection',
         'unfolding_central', 'unfolding_central_raw',
         'unfolding_powheg_pythia8', 'unfolding_powheg_pythia8_raw',
-        'unfolding_amcatnlo', 'unfolding_amcatnlo_raw', 
+        'unfolding_amcatnlo_pythia8', 'unfolding_amcatnlo_pythia8_raw', 
         'unfolding_madgraphMLM', 'unfolding_madgraphMLM_raw',
         'unfolding_hdamp_down', 'unfolding_hdamp_down_raw',
         'unfolding_hdamp_up', 'unfolding_hdamp_up_raw',
@@ -363,7 +363,7 @@ class XSectionConfig():
         self.samplesForChi2Comparison = [
             'TTJets_powhegPythia8',
             'TTJets_powhegHerwig',
-            'TTJets_amcatnlo',
+            'TTJets_amcatnloPythia8',
             'TTJets_madgraphMLM'
         ]
         # now fill in the centre of mass dependent values
@@ -429,7 +429,7 @@ class XSectionConfig():
 
         # Unfolding MC Different Generator Samples
         self.unfolding_powheg_pythia8_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV.root' % self.centre_of_mass_energy
-        self.unfolding_amcatnlo_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_amcatnlo.root' % self.centre_of_mass_energy
+        self.unfolding_amcatnlo_pythia8_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_amcatnloPythia8.root' % self.centre_of_mass_energy
         self.unfolding_madgraphMLM_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_madgraph.root' % self.centre_of_mass_energy
         self.unfolding_powheg_herwig_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_powhegherwigpp.root' % self.centre_of_mass_energy
         self.unfolding_amcatnlo_herwig_raw = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_amcatnloherwigpp.root' % self.centre_of_mass_energy
@@ -440,7 +440,7 @@ class XSectionConfig():
 
         # Raw --> asymmetric
         self.unfolding_powheg_pythia8 = self.unfolding_powheg_pythia8_raw.replace( '.root', '_asymmetric_newPS.root' )
-        self.unfolding_amcatnlo = self.unfolding_amcatnlo_raw.replace( '.root', '_asymmetric_newPS.root' )
+        self.unfolding_amcatnlo_pythia8 = self.unfolding_amcatnlo_pythia8_raw.replace( '.root', '_asymmetric_newPS.root' )
         self.unfolding_madgraphMLM = self.unfolding_madgraphMLM_raw.replace( '.root', '_asymmetric_newPS.root' )
         self.unfolding_powheg_herwig = self.unfolding_powheg_herwig_raw.replace( '.root', '_asymmetric_newPS.root' )
         self.unfolding_amcatnlo_herwig = self.unfolding_amcatnlo_herwig_raw.replace( '.root', '_asymmetric_newPS.root' )

--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -2,7 +2,7 @@ from __future__ import division
 import dps.utils.measurement
 
 class XSectionConfig():
-    current_analysis_path = '/hdfs/TopQuarkGroup/ec6821/1.0.9/atOutput/combined/'
+    current_analysis_path = '/hdfs/TopQuarkGroup/ec6821/1.0.10/atOutput/combined/'
     known_centre_of_mass_energies = [13]
     # has to be separate as many variables depend on it
     luminosities = {13:35900}
@@ -80,8 +80,8 @@ class XSectionConfig():
         path_to_files = self.path_to_files
 
         # self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/Moriond2017/'
-        self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/EPS2017/'
-        # self.path_to_unfolding_histograms = 'unfolding/13TeV/'
+        # self.path_to_unfolding_histograms = '/hdfs/TopQuarkGroup/run2/unfolding/13TeV/EPS2017/'
+        self.path_to_unfolding_histograms = 'unfolding/13TeV/'
         path_to_unfolding_histograms = self.path_to_unfolding_histograms
 
         self.luminosity = self.luminosities[self.centre_of_mass_energy]

--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -53,8 +53,6 @@ class XSectionConfig():
         'NJets',
         'lepton_pt',
         'abs_lepton_eta',
-        'abs_lepton_eta_muonBins',
-        'abs_lepton_eta_electronBins',
         'abs_lepton_eta_coarse'
     ]
 
@@ -68,8 +66,6 @@ class XSectionConfig():
         'bjets_pt', 
         'bjets_eta',
         'abs_bjets_eta',
-        'abs_lepton_eta_muonBins',
-        'abs_lepton_eta_electronBins',
         'abs_lepton_eta_coarse'
     ]
 
@@ -367,7 +363,7 @@ class XSectionConfig():
         self.samplesForChi2Comparison = [
             'TTJets_powhegPythia8',
             'TTJets_powhegHerwig',
-            # 'TTJets_amcatnlo',
+            'TTJets_amcatnlo',
             'TTJets_madgraphMLM'
         ]
         # now fill in the centre of mass dependent values
@@ -496,8 +492,13 @@ class XSectionConfig():
 
         self.unfolding_mass_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massdown_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_mass_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massup_asymmetric_newPS.root' % self.centre_of_mass_energy
-        self.unfolding_Lepton_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptondown_asymmetric_newPS.root' % self.centre_of_mass_energy
-        self.unfolding_Lepton_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptonup_asymmetric_newPS.root' % self.centre_of_mass_energy
+        # self.unfolding_Lepton_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptondown_asymmetric_newPS.root' % self.centre_of_mass_energy
+        # self.unfolding_Lepton_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptonup_asymmetric_newPS.root' % self.centre_of_mass_energy
+        self.unfolding_Electron_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_electrondown_asymmetric_newPS.root' % self.centre_of_mass_energy
+        self.unfolding_Electron_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_electronup_asymmetric_newPS.root' % self.centre_of_mass_energy
+        self.unfolding_Muon_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_muondown_asymmetric_newPS.root' % self.centre_of_mass_energy
+        self.unfolding_Muon_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_muonup_asymmetric_newPS.root' % self.centre_of_mass_energy
+        
         self.unfolding_jes_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_jesdown_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_jes_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_jesup_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_jer_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_jerdown_asymmetric_newPS.root' % self.centre_of_mass_energy

--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -2,7 +2,7 @@ from __future__ import division
 import dps.utils.measurement
 
 class XSectionConfig():
-    current_analysis_path = '/hdfs/TopQuarkGroup/ec6821/1.0.10/atOutput/combined/'
+    current_analysis_path = '/hdfs/TopQuarkGroup/ec6821/1.0.12/atOutput/combined/'
     known_centre_of_mass_energies = [13]
     # has to be separate as many variables depend on it
     luminosities = {13:35900}
@@ -52,7 +52,10 @@ class XSectionConfig():
         'WPT',
         'NJets',
         'lepton_pt',
-        'abs_lepton_eta'
+        'abs_lepton_eta',
+        'abs_lepton_eta_muonBins',
+        'abs_lepton_eta_electronBins',
+        'abs_lepton_eta_coarse'
     ]
 
     # Used in 01
@@ -64,7 +67,10 @@ class XSectionConfig():
         'abs_lepton_eta', 
         'bjets_pt', 
         'bjets_eta',
-        'abs_bjets_eta'
+        'abs_bjets_eta',
+        'abs_lepton_eta_muonBins',
+        'abs_lepton_eta_electronBins',
+        'abs_lepton_eta_coarse'
     ]
 
     def __init__( self, centre_of_mass_energy ):
@@ -361,7 +367,7 @@ class XSectionConfig():
         self.samplesForChi2Comparison = [
             'TTJets_powhegPythia8',
             'TTJets_powhegHerwig',
-            'TTJets_amcatnlo',
+            # 'TTJets_amcatnlo',
             'TTJets_madgraphMLM'
         ]
         # now fill in the centre of mass dependent values
@@ -615,23 +621,19 @@ class XSectionConfig():
         path_to_files = self.path_to_files
 
         self.new_luminosity = 35900
-
-        ### Estimated luminosity for each period
-        # # B
-        # self.new_luminosity = 5790
-        # # C
-        # self.new_luminosity = 2570
-        # # D
-        # self.new_luminosity = 4250
-        # # E
-        # self.new_luminosity = 4010
-        # # F
-        # self.new_luminosity = 3100
-        # # G
-        # self.new_luminosiBty = 7540
-        # H
         # self.new_luminosity = 8610
 
+        ### Estimated luminosity for each period
+        # B
+        self.new_luminosity_periods = {
+            'B' : 5790,
+            'C' : 2570,
+            'D' : 4250,
+            'E' : 4010,
+            'F' : 3100,
+            'G' : 7540,
+            'H' : 8610,
+        }
         self.ttbar_xsection = 831.76  # pb
 
         self.rate_changing_systematics = {
@@ -648,6 +650,9 @@ class XSectionConfig():
             "ST" : 0.0014859830286,
             "MET" : 0.00186599526208,
             "abs_lepton_eta" : 1.1970850305e-08,
+            "abs_lepton_eta_muonBins" : 1.1970850305e-08,
+            "abs_lepton_eta_electronBins" : 1.1970850305e-08,
+            "abs_lepton_eta_coarse" : 1.1970850305e-08,
         }
 
         self.tau_values_muon = {
@@ -658,6 +663,10 @@ class XSectionConfig():
             "ST" : 0.00192109241721,
             "MET" : 0.00240030731786,
             "abs_lepton_eta" : 2.29348568572e-06,
+            "abs_lepton_eta_muonBins" : 2.29348568572e-06,
+            "abs_lepton_eta_electronBins" : 2.29348568572e-06,
+            "abs_lepton_eta_coarse" : 2.29348568572e-06,
+
         }
 
         self.tau_values_combined = {
@@ -668,6 +677,10 @@ class XSectionConfig():
             "ST" : 0,
             "MET" : 0,
             "abs_lepton_eta" : 0,
+            "abs_lepton_eta_muonBins" : 0,
+            "abs_lepton_eta_electronBins" : 0,
+            "abs_lepton_eta_coarse" : 0,
+
            }
 
         # self.categories_and_prefixes['PU_down'] = '_PU_65835mb'

--- a/dps/config/xsection.py
+++ b/dps/config/xsection.py
@@ -492,8 +492,6 @@ class XSectionConfig():
 
         self.unfolding_mass_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massdown_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_mass_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_massup_asymmetric_newPS.root' % self.centre_of_mass_energy
-        # self.unfolding_Lepton_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptondown_asymmetric_newPS.root' % self.centre_of_mass_energy
-        # self.unfolding_Lepton_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_leptonup_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_Electron_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_electrondown_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_Electron_up = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_electronup_asymmetric_newPS.root' % self.centre_of_mass_energy
         self.unfolding_Muon_down = path_to_unfolding_histograms + 'unfolding_TTJets_%dTeV_muondown_asymmetric_newPS.root' % self.centre_of_mass_energy
@@ -651,8 +649,6 @@ class XSectionConfig():
             "ST" : 0.0014859830286,
             "MET" : 0.00186599526208,
             "abs_lepton_eta" : 1.1970850305e-08,
-            "abs_lepton_eta_muonBins" : 1.1970850305e-08,
-            "abs_lepton_eta_electronBins" : 1.1970850305e-08,
             "abs_lepton_eta_coarse" : 1.1970850305e-08,
         }
 
@@ -664,8 +660,6 @@ class XSectionConfig():
             "ST" : 0.00192109241721,
             "MET" : 0.00240030731786,
             "abs_lepton_eta" : 2.29348568572e-06,
-            "abs_lepton_eta_muonBins" : 2.29348568572e-06,
-            "abs_lepton_eta_electronBins" : 2.29348568572e-06,
             "abs_lepton_eta_coarse" : 2.29348568572e-06,
 
         }
@@ -678,8 +672,6 @@ class XSectionConfig():
             "ST" : 0,
             "MET" : 0,
             "abs_lepton_eta" : 0,
-            "abs_lepton_eta_muonBins" : 0,
-            "abs_lepton_eta_electronBins" : 0,
             "abs_lepton_eta_coarse" : 0,
 
            }

--- a/dps/experimental/condor/01b/01_fit.description
+++ b/dps/experimental/condor/01b/01_fit.description
@@ -16,4 +16,4 @@ request_memory=500
 # use the ENV that is provided
 getenv = true
 
-queue 7
+queue 10

--- a/dps/experimental/condor/01b/01_fit.description
+++ b/dps/experimental/condor/01b/01_fit.description
@@ -16,4 +16,4 @@ request_memory=500
 # use the ENV that is provided
 getenv = true
 
-queue 10
+queue 8

--- a/dps/experimental/condor/01b/run01_forAllOptions.py
+++ b/dps/experimental/condor/01b/run01_forAllOptions.py
@@ -17,6 +17,9 @@ vars = [
 	'NJets --visiblePS',
 	'lepton_pt --visiblePS',
 	'abs_lepton_eta --visiblePS',
+	'abs_lepton_eta_coarse --visiblePS',
+	'abs_lepton_eta_muonBins --visiblePS',
+	'abs_lepton_eta_electronBins --visiblePS',
 
 	# 'hadTopRap',
 	# 'lepTopPt',

--- a/dps/experimental/condor/01b/run01_forAllOptions.py
+++ b/dps/experimental/condor/01b/run01_forAllOptions.py
@@ -18,8 +18,6 @@ vars = [
 	'lepton_pt --visiblePS',
 	'abs_lepton_eta --visiblePS',
 	'abs_lepton_eta_coarse --visiblePS',
-	'abs_lepton_eta_muonBins --visiblePS',
-	'abs_lepton_eta_electronBins --visiblePS',
 
 	# 'hadTopRap',
 	# 'lepTopPt',

--- a/dps/experimental/condor/01b/run_01.sh
+++ b/dps/experimental/condor/01b/run_01.sh
@@ -22,8 +22,8 @@ time python dps/experimental/condor/01b/run01_forAllOptions.py -n $1
 echo "Done"
 ls
 echo "Tarring"
-tar -cf output_$1.tar data
+tar -cf output_controlBins_$1.tar data
 ls
 echo "Moving"
-mv output_$1.tar ${_CONDOR_JOB_IWD}/.
+mv output_controlBins_$1.tar ${_CONDOR_JOB_IWD}/.
 ls ${_CONDOR_JOB_IWD}/

--- a/dps/experimental/condor/01b/run_01.sh
+++ b/dps/experimental/condor/01b/run_01.sh
@@ -22,8 +22,8 @@ time python dps/experimental/condor/01b/run01_forAllOptions.py -n $1
 echo "Done"
 ls
 echo "Tarring"
-tar -cf output_controlBins_$1.tar data
+tar -cf output_$1.tar data
 ls
 echo "Moving"
-mv output_controlBins_$1.tar ${_CONDOR_JOB_IWD}/.
+mv output_$1.tar ${_CONDOR_JOB_IWD}/.
 ls ${_CONDOR_JOB_IWD}/

--- a/dps/utils/ROOT_utils.py
+++ b/dps/utils/ROOT_utils.py
@@ -6,6 +6,7 @@ Created on 19 Jan 2013
 from rootpy.logger import logging
 from rootpy.io import File
 from ROOT import gROOT, TH1F
+from rootpy.tree import TreeChain
 from rootpy.plotting import Hist
 gcd = gROOT.cd
 import dps.config.summations_common as sumations
@@ -130,9 +131,11 @@ def get_histograms_from_trees(
     weightAndSelection = '( %s ) * ( %s )' % ( weightBranch, selection )
 
     for sample, input_file in files.iteritems():
-        root_file = File( input_file )
 
-        get_tree = root_file.Get
+        # if not isinstance( input_file ), list :
+        # root_file = File( input_file )
+
+        # get_tree = root_file.Get
         histograms[sample] = {}
 
         for tree in trees:
@@ -141,9 +144,26 @@ def get_histograms_from_trees(
             if 'data' in sample and ( 'Up' in tempTree or 'Down' in tempTree ) :
                 tempTree = tempTree.replace('_'+tempTree.split('_')[-1],'')
 
-            currentTree = get_tree( tempTree )
+
+            chain = None;
+            if isinstance( input_file, list ):
+                chain = TreeChain(tempTree, input_file);
+                # for f in input_file:
+                #     chain.Add(f)
+            else:
+                chain = TreeChain(tempTree, [input_file]);
+                # chain.Add( input_file )
+
+            weightAndSelection = '( %s ) * ( %s )' % ( weightBranch, selection )
+            if 'data' in sample and 'Muon' in weightBranch:
+                weightAndSelection = weightAndSelection.replace('MuonEfficiencyCorrection_etaBins','1')
+                # weightAndSelection = '( %s * topPtWeight ) * ( %s )' % ( weightBranch, selection )
+                print sample, input_file, weightAndSelection
+
+
+            # currentTree = get_tree( tempTree )
             root_histogram = Hist( nBins, xMin, xMax)
-            currentTree.Draw(branch, weightAndSelection, hist = root_histogram)
+            chain.Draw(branch, weightAndSelection, hist = root_histogram)
             if not is_valid_histogram( root_histogram, tree, input_file):
                 return
 
@@ -156,7 +176,19 @@ def get_histograms_from_trees(
             nHistograms += 1
             histograms[sample][tree] = root_histogram.Clone()
 
-        root_file.Close()
+        # root_file.Close()
+
+        # else:
+        #     for tree in trees:
+        #         chain = ROOT.TChain(tree);
+
+        #         if isinstance( input_file, list ):
+        #             for f in input_file:
+        #                 chain.Add(f)
+        #         else:
+        #             chain.Add( input_file )
+
+
     return histograms
 
 @rul.trace()

--- a/dps/utils/ROOT_utils.py
+++ b/dps/utils/ROOT_utils.py
@@ -132,10 +132,6 @@ def get_histograms_from_trees(
 
     for sample, input_file in files.iteritems():
 
-        # if not isinstance( input_file ), list :
-        # root_file = File( input_file )
-
-        # get_tree = root_file.Get
         histograms[sample] = {}
 
         for tree in trees:
@@ -147,21 +143,14 @@ def get_histograms_from_trees(
 
             chain = None;
             if isinstance( input_file, list ):
-                chain = TreeChain(tempTree, input_file);
-                # for f in input_file:
-                #     chain.Add(f)
+                for f in input_file:
+                    chain.Add(f)
             else:
                 chain = TreeChain(tempTree, [input_file]);
-                # chain.Add( input_file )
+
 
             weightAndSelection = '( %s ) * ( %s )' % ( weightBranch, selection )
-            if 'data' in sample and 'Muon' in weightBranch:
-                weightAndSelection = weightAndSelection.replace('MuonEfficiencyCorrection_etaBins','1')
-                # weightAndSelection = '( %s * topPtWeight ) * ( %s )' % ( weightBranch, selection )
-                print sample, input_file, weightAndSelection
 
-
-            # currentTree = get_tree( tempTree )
             root_histogram = Hist( nBins, xMin, xMax)
             chain.Draw(branch, weightAndSelection, hist = root_histogram)
             if not is_valid_histogram( root_histogram, tree, input_file):
@@ -175,19 +164,6 @@ def get_histograms_from_trees(
             gcd()
             nHistograms += 1
             histograms[sample][tree] = root_histogram.Clone()
-
-        # root_file.Close()
-
-        # else:
-        #     for tree in trees:
-        #         chain = ROOT.TChain(tree);
-
-        #         if isinstance( input_file, list ):
-        #             for f in input_file:
-        #                 chain.Add(f)
-        #         else:
-        #             chain.Add( input_file )
-
 
     return histograms
 

--- a/dps/utils/systematic.py
+++ b/dps/utils/systematic.py
@@ -149,7 +149,6 @@ def read_xsection_measurement(options, category):
             norm        = norm,
         )
 
-    print (filename)
     measurement = read_tuple_from_file( filename )
 
     xsection_unfolded = measurement['TTJets_unfolded']
@@ -220,6 +219,12 @@ def get_mc_data_difference(options, mc_xsections, data_xsections):
                 diff = []
                 for j in range(0, len( data_xsections[source][i] )):
                     diff.append( data_xsections[source][i][j] - central_mc[j][0] )
+                #     if source is 'Muon' and j == 1:
+                #         print (source, diff)
+                #         diff[-1] *= 1000
+                #         print (diff)
+                # if source is 'Muon':
+                #     print (diff)
                 data_mc_difference[source].append( diff )
 
     return data_mc_difference
@@ -465,6 +470,22 @@ def get_symmetrised_systematic_uncertainty(options, syst_unc_x_secs ):
                 options, 
                 isTopMassSystematic,
             )
+
+            # if systematic is 'Muon' or systematic is 'Electron':
+            #     for i in range(0,len(symmetrised_uncertainties)):
+            #         symmetrised_uncertainties[i] *=150
+
+            # if systematic is 'Muon':
+            #     symmetrised_uncertainties[1] *= 150
+            #     symmetrised_uncertainties[10] *= 150
+            #     symmetrised_uncertainties[11] *= 150
+            #     symmetrised_uncertainties[12] *= 150
+
+                # print ('Muon',symmetrised_uncertainties)
+
+            # if systematic is 'Electron':
+            #     symmetrised_uncertainties[0] *= 100
+            #     print ('Electron',symmetrised_uncertainties)
 
             xsections_with_symmetrised_systematics[systematic] = [
                 symmetrised_uncertainties, 
@@ -749,10 +770,10 @@ def generate_total_covariance(options, all_covariances, all_correlations):
     create_covariance_matrix( cor_tot, cor_outfile )
 
     # Plot the total matrices
-    make_covariance_plot( options, 'Stat', cov_stat, label='Covariance' )
-    make_covariance_plot( options, 'Total', cov_tot, label='Covariance' )
-    make_covariance_plot( options, 'Stat', cor_stat, label='Correlation' )
-    make_covariance_plot( options, 'Total', cor_tot, label='Correlation' )
+    # make_covariance_plot( options, 'Stat', cov_stat, label='Covariance' )
+    # make_covariance_plot( options, 'Total', cov_tot, label='Covariance' )
+    # make_covariance_plot( options, 'Stat', cor_stat, label='Correlation' )
+    # make_covariance_plot( options, 'Total', cor_tot, label='Correlation' )
     return
 
 # @profile(stream=fp)

--- a/dps/utils/systematic.py
+++ b/dps/utils/systematic.py
@@ -219,12 +219,6 @@ def get_mc_data_difference(options, mc_xsections, data_xsections):
                 diff = []
                 for j in range(0, len( data_xsections[source][i] )):
                     diff.append( data_xsections[source][i][j] - central_mc[j][0] )
-                #     if source is 'Muon' and j == 1:
-                #         print (source, diff)
-                #         diff[-1] *= 1000
-                #         print (diff)
-                # if source is 'Muon':
-                #     print (diff)
                 data_mc_difference[source].append( diff )
 
     return data_mc_difference
@@ -754,10 +748,10 @@ def generate_total_covariance(options, all_covariances, all_correlations):
     create_covariance_matrix( cor_tot, cor_outfile )
 
     # Plot the total matrices
-    # make_covariance_plot( options, 'Stat', cov_stat, label='Covariance' )
-    # make_covariance_plot( options, 'Total', cov_tot, label='Covariance' )
-    # make_covariance_plot( options, 'Stat', cor_stat, label='Correlation' )
-    # make_covariance_plot( options, 'Total', cor_tot, label='Correlation' )
+    make_covariance_plot( options, 'Stat', cov_stat, label='Covariance' )
+    make_covariance_plot( options, 'Total', cov_tot, label='Covariance' )
+    make_covariance_plot( options, 'Stat', cor_stat, label='Correlation' )
+    make_covariance_plot( options, 'Total', cor_tot, label='Correlation' )
     return
 
 # @profile(stream=fp)

--- a/dps/utils/systematic.py
+++ b/dps/utils/systematic.py
@@ -471,22 +471,6 @@ def get_symmetrised_systematic_uncertainty(options, syst_unc_x_secs ):
                 isTopMassSystematic,
             )
 
-            # if systematic is 'Muon' or systematic is 'Electron':
-            #     for i in range(0,len(symmetrised_uncertainties)):
-            #         symmetrised_uncertainties[i] *=150
-
-            # if systematic is 'Muon':
-            #     symmetrised_uncertainties[1] *= 150
-            #     symmetrised_uncertainties[10] *= 150
-            #     symmetrised_uncertainties[11] *= 150
-            #     symmetrised_uncertainties[12] *= 150
-
-                # print ('Muon',symmetrised_uncertainties)
-
-            # if systematic is 'Electron':
-            #     symmetrised_uncertainties[0] *= 100
-            #     print ('Electron',symmetrised_uncertainties)
-
             xsections_with_symmetrised_systematics[systematic] = [
                 symmetrised_uncertainties, 
                 signed_uncertainties,


### PR DESCRIPTION
- Add abs_lepton_eta_coarse (same variable, fewer bins).
- Treat uncertainties in electron and muon scale factors as uncorrelated sources.
- For lepton eta, use scale factors derived in bins of eta only (finer binning possible)
- make_control_plots_fromTrees.py can produce control plots from unmerged AT output.